### PR TITLE
Allow setting different grib keys for ensemble mean and std

### DIFF
--- a/src/pproc/ensms.py
+++ b/src/pproc/ensms.py
@@ -62,8 +62,8 @@ class EnsmsConfig(common.Config):
         self._fdb = None
 
         self.out_keys = self.options.get("out_keys", {})
-        self.out_keys_em = dict({"type": "em"}, **self.options.get("out_keys_em", {}))
-        self.out_keys_es = dict({"type": "es"}, **self.options.get("out_keys_es", {}))
+        self.out_keys_em = {"type": "em", **self.options.get("out_keys_em", {})}
+        self.out_keys_es = {"type": "es", **self.options.get("out_keys_es", {})}
 
         self.parameters = [
             ParamConfig(pname, popt, overrides=self.override_input)


### PR DESCRIPTION
Required to support grib 2 templates, where the types can differ on other keys such as for `derivedForecast` (https://github.com/wmo-im/GRIB2/blob/master/GRIB2_CodeFlag_4_7_CodeTable_en.csv)