### PR TITLE
Feature/pproc interpol packing, accuracy, edition

### DIFF
--- a/src/pproc/interpol.py
+++ b/src/pproc/interpol.py
@@ -22,7 +22,7 @@ class _Regex(object):
         self._pattern = re.compile(pattern)
 
     def __call__(self, value):
-        if not self._pattern.match(value):
+        if not self._pattern.fullmatch(value):
             raise argparse.ArgumentTypeError(
                 "must match '{}'".format(self._pattern.pattern)
             )
@@ -33,21 +33,21 @@ def main(args=None):
     g = r"[ONF][1-9][0-9]*"
     f = r"([0-9]*[.])?[0-9]+"
 
-    _grid = r"^" + f + r"/" + f + r"$|^" + g + r"$"
-    _area = r"^-?" + f + r"/-?" + f + r"/-?" + f + r"/-?" + f + r"$"
-    _accuracy = r"^\d+$"
-    _edition = r"^(1|2)$"
-    _interpolation = r"^(linear|nn|grid-box-average|grid-box-statistics|fail)$"
-    _packing = r"^(ccsds|complex|ieee|second-order|simple)$"
-    _statistics = r"^(maximum|minimum|count)$"
-    _intgrid = r"^" + g + r"$|^(none|source)$"
-    _truncation = r"^[1-9][0-9]*$|^none$"
+    _grid = f + r"/" + f + r"|" + g
+    _area = r"-?" + f + r"/-?" + f + r"/-?" + f + r"/-?" + f
+    _accuracy = r"\d+"
+    _edition = r"1|2"
+    _interpolation = r"linear|nn|grid-box-average|grid-box-statistics|fail"
+    _packing = r"ccsds|complex|ieee|second-order|simple"
+    _statistics = r"maximum|minimum|count"
+    _intgrid = g + r"|none|source"
+    _truncation = r"[1-9][0-9]*|none"
 
     grids = path.join(mir.home(), "etc", "mir", "grids.yaml")
     if path.exists(grids):
         with open(grids) as file:
             for key in yaml.safe_load(file).keys():
-                _grid = _grid + r"|^" + key + r"$"
+                _grid = _grid + r"|" + key
 
     arg = argparse.ArgumentParser()
 

--- a/src/pproc/interpol.py
+++ b/src/pproc/interpol.py
@@ -35,7 +35,10 @@ def main(args=None):
 
     _grid = r"^" + f + r"/" + f + r"$|^" + g + r"$"
     _area = r"^-?" + f + r"/-?" + f + r"/-?" + f + r"/-?" + f + r"$"
+    _accuracy = r"^\d+$"
+    _edition = r"^(1|2)$"
     _interpolation = r"^(linear|nn|grid-box-average|grid-box-statistics|fail)$"
+    _packing = r"^(ccsds|complex|ieee|second-order|simple)$"
     _statistics = r"^(maximum|minimum|count)$"
     _intgrid = r"^" + g + r"$|^(none|source)$"
     _truncation = r"^[1-9][0-9]*$|^none$"
@@ -66,6 +69,24 @@ def main(args=None):
         "--interpolation",
         type=_Regex(_interpolation),
         help="interpolation method (" + _interpolation + ")",
+    )
+
+    arg.add_argument(
+        "--packing",
+        type=_Regex(_packing),
+        help="packing method (GRIB packingType, " + _packing + ")",
+    )
+
+    arg.add_argument(
+        "--accuracy",
+        type=_Regex(_accuracy),
+        help="accuracy (GRIB bitsPerValue, " + _accuracy + ")",
+    )
+
+    arg.add_argument(
+        "--edition",
+        type=_Regex(_edition),
+        help="edition (GRIB edition, " + _edition + ")",
     )
 
     arg.add_argument(
@@ -115,6 +136,9 @@ def main(args=None):
         "interpolation",
         "interpolation_statistics",
         "intgrid",
+        "packing",
+        "accuracy",
+        "edition",
         "truncation",
     ]:
         if hasattr(args, k):


### PR DESCRIPTION
Added packing, accuracy and edition options to the cli pproc-interpol tool I added edition and accuracy because packing=ccsds can otherwise only be applied to fields already in edition=2.

There are a few omissions to packing as I didn't want to expose all of its possible values, which can be added at any given time.