### PR TITLE
Release pipeline

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,12 @@
+name: cd
+
+on:
+  push:
+    tags:
+      - '**'
+
+jobs:
+
+  pypi:
+    uses: ecmwf/reusable-workflows/.github/workflows/cd-pypi.yml@v2
+    secrets: inherit

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,7 +3,7 @@ name: cd
 on:
   push:
     tags:
-      - '**'
+      - '[0-9]+.[0-9]+.[0-9]+' # NOTE there are other tags for generating "unstable modules", those should *not* trigger pypi upload
 
 jobs:
 

--- a/.github/workflows/test-pypi.yml
+++ b/.github/workflows/test-pypi.yml
@@ -1,0 +1,11 @@
+name: test cd
+
+on:
+  workflow_dispatch: ~
+
+jobs:
+  deploy:
+    uses: ecmwf/reusable-workflows/.github/workflows/cd-pypi.yml@v2
+    secrets: inherit
+    with:
+      testpypi: true

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ profile_default/
 ipython_config.py
 
 tests/data
+
+
+src/pproc/_version.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools>=78", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "pproc"
 description = "ECMWF Post-processing tools"
-version = "1.4.0"
 readme = "README.md"
-license = { text = "Apache License Version 2.0" }
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 authors = [
     { name = "European Centre for Medium-Range Weather Forecasts (ECMWF)", email = "software.support@ecmwf.int" },
 ]
@@ -33,6 +33,7 @@ dependencies = [
     "pydantic",
     "conflator >= 0.1.7",
 ]
+dynamic = ["version"]
 
 [project.optional-dependencies]
 tcycl = ["pyinfero >= 0.1.1", "wget"]
@@ -75,3 +76,10 @@ include-package-data = true
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.setuptools_scm]
+write_to = "src/pproc/_version.py"
+write_to_template = '''# Do not change! Do not track in version control!
+__version__ = "{version}"
+'''
+local_scheme = "no-local-version"

--- a/src/pproc/__init__.py
+++ b/src/pproc/__init__.py
@@ -8,3 +8,8 @@
 # nor does it submit to any jurisdiction.
 
 from . import clustereps
+
+try:
+    from ._version import __version__
+except ImportError:
+    __version__ = "local"


### PR DESCRIPTION
- Adds tagPush->publishPypi release pipeline
- Adds on-demand publishTestPypi pipeline
- Integrates setuptools_scm for the automated wheel versioning
- Minor pyproject fixes

Tested as a local build, but a CI test cannot be done until this is merged to default branch