### PR TITLE
Bug fix scaling in `Parameter` class

### DIFF
--- a/src/pproc/common/parameter.py
+++ b/src/pproc/common/parameter.py
@@ -67,7 +67,7 @@ class Parameter:
         self.base_request["time"] = dt.strftime("%H")
         self.overrides = overrides
         self.interpolation_keys = param_cfg.get("interpolation_keys", None)
-        self.scale_data = int(param_cfg.get("scale", 1))
+        self.scale_data = float(param_cfg.get("scale", 1.0))
 
     def retrieve_data(
         self, fdb, step: common.AnyStep, join_dim: str = "number", **kwargs

--- a/src/pproc/thermal_indices.py
+++ b/src/pproc/thermal_indices.py
@@ -62,10 +62,10 @@ def process_step(args, config, window_id, fields, recovery):
         ws = indices.calc_field("10si", indices.calc_ws, fields)
         config.write(step, ws)
 
-    # Cosine of Solar Zenith Angle - shortName uvcossza - ECMWF product
+    # Cosine of Solar Zenith Angle - shortName cossza - ECMWF product
     # TODO: 214001 only exists for GRIB1 -- but here we use it for GRIB2 (waiting for WMO)
-    if config.is_target_param(step, {"uvcossza", 214001}):
-        cossza = indices.calc_field("uvcossza", indices.calc_cossza_int, fields)
+    if config.is_target_param(step, {"cossza", 214001}):
+        cossza = indices.calc_field("cossza", indices.calc_cossza_int, fields)
         config.write(step, cossza)
 
     # direct solar radiation - shortName dsrp - ECMWF product

--- a/src/pproc/thermo/helpers.py
+++ b/src/pproc/thermo/helpers.py
@@ -17,7 +17,7 @@ MRT_DIFF_LOW = -30
 
 # parameter to units
 units = {
-    "uvcossza": "",
+    "cossza": "",
     "2t": "K",
     "2d": "K",
     "wcf": "K",

--- a/src/pproc/thermo/indices.py
+++ b/src/pproc/thermo/indices.py
@@ -145,7 +145,7 @@ class ComputeIndices:
             return fields.sel(param="dsrp")
 
         fdir = field_values(fields, "fdir")  # W/m2
-        cossza = self.calc_field("uvcossza", self.calc_cossza_int, fields)[0].values
+        cossza = self.calc_field("cossza", self.calc_cossza_int, fields)[0].values
 
         dsrp = thermofeel.approximate_dsrp(fdir, cossza)
 
@@ -277,7 +277,7 @@ class ComputeIndices:
     @metered("mrt", out=logger.debug)
     def calc_mrt(self, fields):
 
-        cossza = self.calc_field("uvcossza", self.calc_cossza_int, fields)[0].values
+        cossza = self.calc_field("cossza", self.calc_cossza_int, fields)[0].values
         dsrp = self.calc_field("dsrp", self.calc_dsrp, fields)[0].values
 
         delta = step_interval(fields)


### PR DESCRIPTION
- Allow non-integer scaling in `Parameter` class
- Change `uvcossva` short name to `cossva` for compatibility with eccodes == 2.41.0