### PR TITLE
extreme: Add vmin/vmax options to clip input forecast accumulated values

### DIFF
--- a/src/pproc/config/types.py
+++ b/src/pproc/config/types.py
@@ -259,6 +259,8 @@ class ProbConfig(BaseConfig):
 
 
 class ExtremeParamConfig(ClimParamConfig):
+    vmin: Optional[float] = None
+    vmax: Optional[float] = None
     eps: float = -1.0
     sot: list[int] = []
     cpf_eps: Optional[float] = None

--- a/src/pproc/extreme.py
+++ b/src/pproc/extreme.py
@@ -86,6 +86,9 @@ def compute_indices(
         ens = accum.values
         assert ens is not None
 
+        if param.vmin is not None or param.vmax is not None:
+            np.clip(ens, param.vmin, param.vmax, out=ens)
+
         for name, index in param.indices.items():
             target = getattr(cfg.outputs, name).target
             index.compute(clim, ens, target, message_template, template_extreme)

--- a/src/pproc/extremes/indices.py
+++ b/src/pproc/extremes/indices.py
@@ -43,7 +43,7 @@ class Index(metaclass=ABCMeta):
 class EFI(Index):
     def __init__(self, options):
         super().__init__(options)
-        self.eps = float(options["eps"]) if "eps" in options else -1.0
+        self.eps = float(options.get("eps", -1.0))
 
     def compute(
         self,
@@ -66,8 +66,8 @@ class EFI(Index):
 class SOT(Index):
     def __init__(self, options):
         super().__init__(options)
-        self.eps = float(options["eps"]) if "eps" in options else -1.0
-        self.sot = list(map(int, options["sot"])) if "sot" in options else []
+        self.eps = float(options.get("eps", -1.0))
+        self.sot = list(map(int, options.get("sot", [])))
 
     def compute(
         self,
@@ -86,7 +86,7 @@ class SOT(Index):
 class CPF(Index):
     def __init__(self, options):
         super().__init__(options)
-        self.eps = float(options["cpf_eps"]) if "cpf_eps" in options else None
+        self.eps = float(options["cpf_eps"]) if options.get("cpf_eps", None) is not None else None
         self.symmetric = options.get("cpf_symmetric", False)
 
     def compute(


### PR DESCRIPTION
### Description

In some cases like total precipitation or wind speed, the aggregated forecast that serves as an input to the extreme forecast indices (EFI/SOT/CPF) can take unphysical values (e.g. lower than 0). This adds configuration options `vmin` and `vmax` to serve as lower and upper limits, respectively.

Additional change: the default values for extreme parameters were not handled correctly, this PR also fixes this


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 