### PR TITLE
Allow scaling of ecPoint outputs 

### DIFF
--- a/src/pproc/common/accumulation.py
+++ b/src/pproc/common/accumulation.py
@@ -443,7 +443,7 @@ class StandardDeviation(Mean):
         mean = super().get_values()
         if mean is None:
             return None
-        return np.sqrt(np.clip(self.sumsq / self.count - mean**2, 0.0, None))
+        return np.sqrt(np.maximum(self.sumsq / self.count - mean**2, 0.0))
 
 
 class DeaccumulationWrapper(Accumulation):

--- a/src/pproc/common/accumulation.py
+++ b/src/pproc/common/accumulation.py
@@ -443,7 +443,7 @@ class StandardDeviation(Mean):
         mean = super().get_values()
         if mean is None:
             return None
-        return np.sqrt(self.sumsq / self.count - mean**2)
+        return np.sqrt(np.clip(self.sumsq / self.count - mean**2, 0.0, None))
 
 
 class DeaccumulationWrapper(Accumulation):

--- a/src/pproc/config/types.py
+++ b/src/pproc/config/types.py
@@ -478,7 +478,7 @@ class ProbParamConfig(ClimParamConfig):
 
     def _merge_clim(self, other: Self) -> None:
         return None
-    
+
     def _merge_name(self, other: Self) -> str:
         return self.name
 
@@ -554,7 +554,7 @@ class ProbConfig(BaseConfig):
                     fc_step[x]: clim_step[x] for x in range(len(fc_step))
                 }
         return sorted_requests
-    
+
     def _merge_parameters(self, other: Self = None) -> list[ProbParamConfig]:
         merged_params = [self.parameters[0]]
         other_params = self.parameters[1:]
@@ -954,6 +954,7 @@ class ECPointConfig(QuantilesConfig):
     ]
     predictors: list[str] = ["cpr", "tp", "ws", "mxcape6", "cdir"]
     min_predictand: float = 0.04
+    scale_outputs: Optional[float] = None
 
     @classmethod
     def from_schema(cls, schema_config: dict, **overrides) -> Self:

--- a/src/pproc/config/types.py
+++ b/src/pproc/config/types.py
@@ -959,7 +959,7 @@ class ECPointConfig(QuantilesConfig):
     @classmethod
     def from_schema(cls, schema_config: dict, **overrides) -> Self:
         overrides = overrides.copy()
-        for var in ["bp_location", "fer_location", "predictors", "min_predictant"]:
+        for var in ["bp_location", "fer_location", "predictors", "min_predictant", "scale_outputs"]:
             if var in schema_config:
                 overrides.setdefault(var, schema_config.pop(var))
         return super().from_schema(schema_config, **overrides)

--- a/src/pproc/config/types.py
+++ b/src/pproc/config/types.py
@@ -1027,9 +1027,3 @@ class ECPointConfig(QuantilesConfig):
         req.pop("quantile")
         self._append_number(param, req)
         return req
-
-    def in_mars(self, sources: Optional[list[str]] = None) -> Iterator:
-        for req in super().in_mars(sources):
-            if req.get("model", None) == "ecPoint":
-                req.pop("model")
-            yield req

--- a/src/pproc/config/types.py
+++ b/src/pproc/config/types.py
@@ -1027,3 +1027,9 @@ class ECPointConfig(QuantilesConfig):
         req.pop("quantile")
         self._append_number(param, req)
         return req
+
+    def in_mars(self, sources: Optional[list[str]] = None) -> Iterator:
+        for req in super().in_mars(sources):
+            if req.get("model", None) == "ecPoint":
+                req.pop("model")
+            yield req

--- a/src/pproc/config/types.py
+++ b/src/pproc/config/types.py
@@ -959,7 +959,13 @@ class ECPointConfig(QuantilesConfig):
     @classmethod
     def from_schema(cls, schema_config: dict, **overrides) -> Self:
         overrides = overrides.copy()
-        for var in ["bp_location", "fer_location", "predictors", "min_predictant", "scale_outputs"]:
+        for var in [
+            "bp_location",
+            "fer_location",
+            "predictors",
+            "min_predictant",
+            "scale_outputs",
+        ]:
             if var in schema_config:
                 overrides.setdefault(var, schema_config.pop(var))
         return super().from_schema(schema_config, **overrides)

--- a/src/pproc/ecpoint.py
+++ b/src/pproc/ecpoint.py
@@ -271,6 +271,11 @@ def ecpoint_iteration(
             config.parallelisation.ens_batch_size,
         )
 
+    # Scale outputs, needed for grib 2 rainfall in metres
+    if config.scale_outputs:
+        pt_bc_allens_allwt *= config.scale_outputs
+        grid_bc_allens_allwt *= config.scale_outputs
+
     # Save the grid-scale outputs and weather types for each member
     out_bs = config.outputs.bs
     out_wt = config.outputs.wt

--- a/src/pproc/ecpoint.py
+++ b/src/pproc/ecpoint.py
@@ -272,7 +272,7 @@ def ecpoint_iteration(
         )
 
     # Scale outputs, needed for grib 2 rainfall in metres
-    if config.scale_outputs:
+    if config.scale_outputs is not None:
         pt_bc_allens_allwt *= config.scale_outputs
         grid_bc_allens_allwt *= config.scale_outputs
 

--- a/src/pproc/ecpoint.py
+++ b/src/pproc/ecpoint.py
@@ -236,7 +236,11 @@ def compute_weather_types(
                 )
             )
 
-    return pt_bc_allens_allwt, grid_bc_allens_allwt, wt_allens_allwt
+    return (
+        np.asarray(pt_bc_allens_allwt),
+        np.asarray(grid_bc_allens_allwt),
+        np.asarray(wt_allens_allwt),
+    )
 
 
 def ecpoint_iteration(

--- a/src/pproc/schema/input.py
+++ b/src/pproc/schema/input.py
@@ -343,12 +343,19 @@ class InputSchema(BaseSchema):
         cls, request: dict, pop: Optional[list[str]] = []
     ) -> dict:
         out = copy.deepcopy(request)
-        # Remove number from output types e.g. sot where number is not
-        # associated with ensemble number
-        if request["type"] not in ["pf", "fcmean", "fcmax", "fcstdev", "fcmin", "fc"]:
-            out.pop("number", None)
-        for key in pop + ["step", "fcmonth", "quantile"]:
-            out.pop(key, None)
+        ignore_inheritance = {
+            "number": lambda req: (
+                req["type"] not in ["pf", "fcmean", "fcmax", "fcstdev", "fcmin", "fc"]
+            ),
+            "model": lambda req: req.get("model", None) == "ecPoint",
+            "step": None,
+            "fcmonth": None,
+            "quantile": None,
+        }
+        ignore_inheritance.update({x: None for x in pop})
+        for key, condition in ignore_inheritance.items():
+            if condition is None or condition(request):
+                out.pop(key, None)
         return format_request(out)
 
     def inputs(self, output_request: dict, step_schema: StepSchema) -> Iterator[dict]:

--- a/tests/common/test_accumulation.py
+++ b/tests/common/test_accumulation.py
@@ -297,6 +297,17 @@ def test_accumulations(config, acc_cls, used_coords, exp_values):
     np.testing.assert_almost_equal(acc.get_values(), exp_values)
 
 
+def test_std_zero():
+    acc = create_accumulation(
+        {"operation": "standard_deviation", "coords": {"to": 4, "by": 2}}
+    )
+
+    data = np.ones((2, 3)) * 0.1
+    for c in [0, 2, 4]:
+        acc.feed(c, data)
+    np.testing.assert_almost_equal(acc.get_values(), np.zeros((2, 3)))
+
+
 def test_convert_dim():
     acc = Mean(range(25, 6))
     assert convert_dim(("step", acc)) == Dimension("step", acc)


### PR DESCRIPTION
### Description
Add configuration to option to scale ecpoint gridded and point outputs, required for conversion to grib 2 rainfall units of metres. ecPoint outputs in grib 2 also have additional mars keyword `model=ecPoint`, which is removed from input requests. Finally, bug fixed StandardDeviation accumulation values below 0.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 