### PR TITLE
Minor change to HistParamConfig

### DIFF
--- a/src/pproc/config/types.py
+++ b/src/pproc/config/types.py
@@ -211,7 +211,7 @@ class MonthlyStatsConfig(BaseConfig):
 
 class HistParamConfig(ParamConfig):
     bins: List[float]
-    mod: Optional[int] = None
+    mod: Optional[Union[float | int]] = None
     normalise: bool = True
     scale_out: Optional[float] = None
 

--- a/src/pproc/histogram.py
+++ b/src/pproc/histogram.py
@@ -174,9 +174,6 @@ def write_iteration(
 ):
     with ResourceMeter(f"{param.name}, window {window_id!s}: Write histogram"):
         hist = accum.values
-        out_keys = fill_template_values(
-            accum.grib_keys(), {"num_fields": np.prod(hist.shape[:-1])}
-        )
         assert hist is not None
         write_histogram(
             hist,
@@ -184,7 +181,7 @@ def write_iteration(
             target,
             param.normalise,
             param.scale_out,
-            out_keys=out_keys,
+            out_keys=accum.grib_keys(),
         )
     recovery.add_checkpoint(param=param.name, window=str(window_id))
 


### PR DESCRIPTION
### Description
Allow float type for `mod` in `HistParamConfig` and don't support templated metadata values in histogram.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 