### PR TITLE
Generalise handling of 24hr predictants

### DIFF
--- a/src/pproc/ecpoint.py
+++ b/src/pproc/ecpoint.py
@@ -359,6 +359,7 @@ def main():
                 total=cfg.total_fields,
             )
         ]
+        num_inputs = requesters[0].total
         dims = {k: set(val) for k, val in managers[0].dims.items()}
         for input_param in param.dependencies.values():
             managers.append(
@@ -382,30 +383,52 @@ def main():
                     total=cfg.total_fields,
                 )
             )
+            num_inputs += requesters[-1].total
+            for k, val in managers[-1].dims.items():
+                dims[k] |= set(val)
+        logger.debug(f"Expected number of inputs: {num_inputs}")
+        logger.debug(f"Dims: {dims}")
         ecpoint_partial = functools.partial(ecpoint_iteration, cfg, param, recover)
+        input_sets = []
         for keys, retrieved_data in parallel_data_retrieval(
             cfg.parallelisation.n_par_read,
             {k: sorted(list(val)) for k, val in dims.items()},
             requesters,
         ):
             ids = ", ".join(f"{k}={v}" for k, v in keys.items())
-            window_id = None
-            fields = None
-            out_keys = {}
             with ResourceMeter(f"{ids}: Compute accumulation"):
                 for index, param_data in enumerate(retrieved_data):
                     param_metadata, ens = param_data
                     for wid, completed_window in managers[index].feed(keys, ens):
                         if index == 0:
-                            window_id = wid
-                            out_keys = completed_window.grib_keys()
-                            fields = earthkit.data.FieldList()
-                        fields += earthkit.data.FieldList.from_array(
+                            logger.debug(f"Creating input set for {wid}")
+                            input_sets.append(
+                                {
+                                    "window_id": wid,
+                                    "out_keys": completed_window.grib_keys(),
+                                    "input_params": None,
+                                }
+                            )
+                        new_field = earthkit.data.FieldList.from_array(
                             completed_window.values, to_ekmetadata(param_metadata)
                         )
+                        field_name = param_metadata[0]["shortName"]
+                        for input_set in input_sets:
+                            if input_set["input_params"] is None:
+                                input_set["input_params"] = new_field
+                            elif (
+                                len(input_set["input_params"].sel(param=field_name))
+                                == 0
+                            ):
+                                input_set["input_params"] += new_field
                     del ens
-                if fields is not None:
-                    ecpoint_partial(window_id, fields, out_keys)
+                checked = 0
+                while checked < len(input_sets):
+                    if len(input_sets[checked]["input_params"]) == num_inputs:
+                        ecpoint_partial(**input_sets[checked])
+                        del input_sets[checked]
+                    else:
+                        checked += 1
 
     recover.clean_file()
 

--- a/src/pproc/ecpt/predictors.py
+++ b/src/pproc/ecpt/predictors.py
@@ -22,18 +22,6 @@ def to_ekmetadata(metadata: list[GribMetadata]) -> list[StandAloneGribMetadata]:
     ]
 
 
-def _retrieve_sr24(
-    config: ECPointConfig, param: ParamConfig, step: int
-) -> earthkit.data.FieldList:
-    requester = ParamRequester(param, config.inputs, config.total_fields, "fc")
-    end_step = max(step, 24)
-    _, start_data = requester.retrieve_data(end_step - 24)
-    metadata, end_data = requester.retrieve_data(end_step)
-    return earthkit.data.FieldList.from_array(
-        end_data - start_data, to_ekmetadata(metadata)
-    )
-
-
 def _local_solar_time(hour: int, longitudes: np.ndarray) -> np.ndarray:
     lst_pos = np.where(longitudes >= 0, hour + (longitudes / 15), 0)
     temp_pos = np.where(lst_pos >= 24, lst_pos - 24, lst_pos)
@@ -82,23 +70,11 @@ def cpr(
     return _ratio(inputs.sel(param="cp").values, inputs.sel(param="tp").values)
 
 
-def cdir(
-    config: ECPointConfig, param: ParamConfig, window: str, inputs: FieldList
-) -> np.ndarray:
-    if len(inputs.sel(param="cdir")) == 0:
-        # Fetch solar radiation if not present. This is to handle the special case of step ranges where
-        # the end step is < 24 (e.g. 0-12) but uses solar radiation over 24hr window and therefore the end
-        # step of the solar radiation window does not match the end step of the tp step interval
-        inputs += _retrieve_sr24(config, param, int(window.split("-")[1]))
-    return inputs.sel(param="cdir").values
-
-
 PREDICTORS = {
     "sdfor": sdfor,
     "lst": lst,
     "ws": ws,
     "cpr": cpr,
-    "cdir": cdir,
 }
 
 


### PR DESCRIPTION
### Description
More general handling of predictants which required 24hr window, and remove special handling of solar radiation. This is to support 12hr ERA5, which requires a few predictants with 24hr minimum accumulation windows.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 