### PR TITLE
Support for ERA5 ecPoint temperature

### DIFF
--- a/src/pproc/common/accumulation.py
+++ b/src/pproc/common/accumulation.py
@@ -446,6 +446,62 @@ class StandardDeviation(Mean):
         return np.sqrt(np.maximum(self.sumsq / self.count - mean**2, 0.0))
 
 
+class Filter(Aggregation):
+    def __init__(
+        self,
+        coords: Coords,
+        filter_op: str,
+        filter_index: int,
+        neighbours: list[int],
+        neighbours_op: Optional[str] = None,
+        sequential: bool = False,
+        metadata: Optional[dict] = None,
+    ):
+        super().__init__(coords, sequential, metadata)
+        if filter_op == "max":
+            self.filter_op = np.argmax
+        elif filter_op == "min":
+            self.filter_op = np.argmin
+        else:
+            raise ValueError(f"Unknown filter op: {filter_op}")
+        self.filter_index = filter_index
+        self.neighbours = neighbours + [0]
+        self.neighbours.sort()
+        self.neighbours_op = getattr(np, neighbours_op or "squeeze")
+
+    def get_values(self) -> Optional[np.ndarray]:
+        aggregated_values = super().get_values()
+        op_indices = self.filter_op(
+            aggregated_values[
+                self.neighbours[0] * -1 :, self.filter_index : self.filter_index + 1
+            ],
+            axis=0,
+            keepdims=True,
+        )
+        indices = np.concatenate([op_indices + n for n in self.neighbours], axis=0)
+        selected_values = np.take_along_axis(aggregated_values, indices, axis=0)
+        return self.neighbours_op(selected_values, axis=0)
+
+    @classmethod
+    def create(
+        cls,
+        operation: str,
+        coords: Coords,
+        config: dict,
+        sequential: bool = False,
+        metadata: Optional[dict] = None,
+    ) -> Accumulation:
+        return cls(
+            coords,
+            filter_op=config["filter_op"],
+            filter_index=config.get("filter_index", 0),
+            neighbours=config.get("neighbours", []),
+            neighbours_op=config.get("neighbours_op", None),
+            sequential=sequential,
+            metadata=metadata,
+        )
+
+
 class DeaccumulationWrapper(Accumulation):
     def __init__(self, accumulation: Accumulation):
         if len(accumulation.coords) < 2:
@@ -540,6 +596,7 @@ def create_accumulation(config: dict) -> Accumulation:
         "histogram": Histogram,
         "aggregation": Aggregation,
         "standard_deviation": StandardDeviation,
+        "filter": Filter,
     }
     cls = known.get(op)
     if cls is None:

--- a/src/pproc/common/accumulation.py
+++ b/src/pproc/common/accumulation.py
@@ -477,11 +477,14 @@ class Filter(Aggregation):
         aggregated_values = super().get_values()
         lshift = max(self.neighbours[0] * -1, 0)
         rshift = len(aggregated_values) - self.neighbours[-1]
+        filter_index = (
+            self.filter_index
+            if self.filter_index >= 0
+            else self.filter_index + len(aggregated_values[0])
+        )
         op_indices = (
             self.filter_op(
-                aggregated_values[
-                    lshift:rshift, self.filter_index : self.filter_index + 1
-                ],
+                aggregated_values[lshift:rshift, filter_index : filter_index + 1],
                 axis=0,
                 keepdims=True,
             )

--- a/src/pproc/common/accumulation.py
+++ b/src/pproc/common/accumulation.py
@@ -467,16 +467,25 @@ class Filter(Aggregation):
         self.filter_index = filter_index
         self.neighbours = neighbours + [0]
         self.neighbours.sort()
+        if len(neighbours) > 1 and neighbours_op is None:
+            raise ValueError(
+                "Must specify neighbours_op in Filter accumulation in neighbours is not empty"
+            )
         self.neighbours_op = getattr(np, neighbours_op or "squeeze")
 
     def get_values(self) -> Optional[np.ndarray]:
         aggregated_values = super().get_values()
-        op_indices = self.filter_op(
-            aggregated_values[
-                self.neighbours[0] * -1 :, self.filter_index : self.filter_index + 1
-            ],
-            axis=0,
-            keepdims=True,
+        lshift = max(self.neighbours[0] * -1, 0)
+        rshift = len(aggregated_values) - self.neighbours[-1]
+        op_indices = (
+            self.filter_op(
+                aggregated_values[
+                    lshift:rshift, self.filter_index : self.filter_index + 1
+                ],
+                axis=0,
+                keepdims=True,
+            )
+            + lshift
         )
         indices = np.concatenate([op_indices + n for n in self.neighbours], axis=0)
         selected_values = np.take_along_axis(aggregated_values, indices, axis=0)

--- a/src/pproc/common/param_requester.py
+++ b/src/pproc/common/param_requester.py
@@ -106,7 +106,7 @@ class ParamRequester:
     def retrieve_data(self, **kwargs) -> Tuple[List[GribMetadata], np.ndarray]:
         metadata = []
         data_list = []
-        templates = None
+        templates = []
         if "step" in kwargs:
             kwargs["step"] = str(kwargs["step"])
         inputs = self.param.input_list(
@@ -123,13 +123,13 @@ class ParamRequester:
             )
             metadata.append(pinput.base_request())
             data_list.append(data)
-            if templates is None:
-                templates = new_templates
+            templates.append(new_templates)
 
         assert templates is not None, "No data fetched"
 
         new_metadata, data_list = self.param.preprocessing.apply(metadata, data_list)
         assert len(data_list) == 1, "More than one output of preprocessing"
+        templates = sum(templates[: len(data_list[0])], [])
         metadata_set = {
             k: v for k, v in new_metadata[0].items() if v != metadata[0].get(k, None)
         }

--- a/src/pproc/common/window.py
+++ b/src/pproc/common/window.py
@@ -12,55 +12,19 @@ from typing import Dict, Iterator, Optional, Tuple, Union, Any
 from pproc.common.grib_helpers import fill_template_values
 
 
-def window_operation_from_config(window_config: dict) -> Dict[str, list]:
-    """
-    Derives window operation from config. If no window operation is explicitly
-    specified then attempts to derive it from the thresholds.
-
-    :param window_config: window configuration dictionary
-    :return: dict mapping window operations to associated thresholds, if any
-    """
-    # Get window operation, or if not provided in config, derive from threshold
-    window_operations = {}
-    if "operation" in window_config:
-        thresholds = window_config.get("thresholds", [])
-        for threshold in thresholds:
-            if isinstance(threshold["value"], str):
-                threshold["value"] = float(threshold["value"])
-        window_operations[window_config["operation"]] = thresholds
-    elif "thresholds" in window_config:
-        # Derive from threshold comparison parameter
-        for threshold in window_config["thresholds"]:
-            if isinstance(threshold["value"], str):
-                threshold["value"] = float(threshold["value"])
-            comparison = threshold["comparison"]
-            if "<" in comparison:
-                operation = "minimum"
-            elif ">" in comparison:
-                operation = "maximum"
-            else:
-                raise RuntimeError(f"Unknown threshold comparison {comparison}")
-            window_operations.setdefault(operation, []).append(threshold)
-    else:
-        window_operations["aggregation"] = []
-
-    return window_operations
-
-
 def translate_window_config(
     coords: Union[list[Any], dict],
-    window_operation: str,
-    include_start: bool,
-    grib_keys: Optional[dict] = None,
+    include_start: bool = False,
+    metadata: Optional[dict] = None,
     deaccumulate: bool = False,
-    **window_options,
+    **extra,
 ) -> Tuple[str, dict]:
     """
     Create window configuration for the given operation
 
     :param coords: step range specification
-    :param window operation: operation supported by accumulation
-    :param grib_keys: additional grib keys to tie to the window
+    :param include_start: if True, include first coord
+    :param metadata: additional grib keys to tie to the window
     :param deaccumulate: if True, deaccumulate steps before performed window operation
     :return: Window name, Accumulation configuration dict
     :raises: ValueError for unsupported window operation string
@@ -86,23 +50,10 @@ def translate_window_config(
         if len(coords) < 2:
             raise ValueError("De-accumulation can not be performed on single coord")
 
-    operation = None
-    extra = {}
-    operation = window_operation
-    if operation in [
-        "sum",
-        "minimum",
-        "maximum",
-        "mean",
-        "aggregation",
-        "standard_deviation",
-    ]:
-        if not include_init:
-            coords = coords[1:]
-    elif operation == "difference_rate":
-        extra["factor"] = window_options.get("factor", 1.0)
+    if not include_init:
+        coords = coords[1:]
 
-    grib_header = {} if grib_keys is None else grib_keys.copy()
+    grib_header = {} if metadata is None else metadata.copy()
     grib_header = fill_template_values(
         grib_header,
         {
@@ -132,7 +83,6 @@ def translate_window_config(
         grib_header["stepRange"] = name
 
     acc_config = {
-        "operation": operation,
         "coords": coords,
         "sequential": True,
         "metadata": grib_header,
@@ -149,29 +99,16 @@ def _iter_legacy_windows(
     prefix: str = "",
 ) -> Iterator[Tuple[str, dict]]:
     for window_index, window_config in enumerate(windows):
-        window_operations = window_operation_from_config(window_config)
-        for operation, thresholds in window_operations.items():
-            coords = window_config["coords"]
-            for coord in coords:
-                include_start = bool(window_config.get("include_start", False))
-                acc_grib_keys = grib_keys.copy()
-                acc_grib_keys.update(window_config.get("metadata", {}))
-                window_name, acc_config = translate_window_config(
-                    coord,
-                    operation,
-                    include_start,
-                    acc_grib_keys,
-                    window_config.get("deaccumulate", False),
-                    factor=float(window_config.get("factor", 1.0)),
-                )
-                window_id = (
-                    f"{prefix}{window_name}_{operation}_{window_index}"
-                    if len(window_operations) > 1
-                    else f"{prefix}{window_name}_{window_index}"
-                )
-                if thresholds:
-                    acc_config["thresholds"] = thresholds
-                yield window_id, acc_config
+        window_config = window_config.copy()
+        for coord in window_config.pop("coords"):
+            coord_config = window_config.copy()
+            acc_grib_keys = grib_keys.copy()
+            acc_grib_keys.update(coord_config.pop("metadata", {}))
+            window_name, acc_config = translate_window_config(
+                coords=coord, metadata=acc_grib_keys, **coord_config
+            )
+            window_id = f"{prefix}{window_name}_{window_index}"
+            yield window_id, acc_config
 
 
 def legacy_window_factory(config: dict, grib_keys: dict) -> Iterator[Tuple[str, dict]]:

--- a/src/pproc/config/param.py
+++ b/src/pproc/config/param.py
@@ -96,7 +96,7 @@ class ParamConfig(BaseModel):
                     },
                     request=[row.dropna().to_dict() for _, row in items.iterrows()],
                 )
-                for _, items in df.groupby("param")
+                for _, items in df.groupby("param", sort=False)
             ]
         return [
             Input(

--- a/src/pproc/config/types.py
+++ b/src/pproc/config/types.py
@@ -1028,6 +1028,8 @@ class ECPointConfig(QuantilesConfig):
         dependencies = {}
         config_dep = config.pop("dependencies")
         for index, (name, param_config) in enumerate(config_dep.items()):
+            if "dtype" in config:
+                param_config.setdefault("dtype", config["dtype"])
             dependencies[name] = super()._populate_param(
                 param_config,
                 paired_requests[index + 1],

--- a/src/pproc/config/types.py
+++ b/src/pproc/config/types.py
@@ -919,6 +919,7 @@ class ThermoConfig(BaseConfig):
 
 class ECPointParamConfig(ParamConfig):
     dependencies: dict[str, ParamConfig]
+    num_inputs: int
     _merge_exclude = ("accumulations", "dependencies")
 
     @model_validator(mode="before")

--- a/src/pproc/config/types.py
+++ b/src/pproc/config/types.py
@@ -31,6 +31,7 @@ from pproc.config.base import BaseConfig, Parallelisation
 from pproc.config import io
 from pproc.config.param import ParamConfig, partial_equality
 from pproc.config.utils import _set, _get, extract_mars, update_request, deep_update
+from pproc.config.preprocessing import Expression
 from pproc.common.stepseq import steprange_to_fcmonth
 from pproc.extremes.indices import Index, SUPPORTED_INDICES, create_indices
 
@@ -962,7 +963,7 @@ class ECPointConfig(QuantilesConfig):
     fer_location: Annotated[
         str, CLIArg("--fer-loc"), Field(description="Location of FER CSV file")
     ]
-    predictors: list[str] = ["cpr", "tp", "ws", "mxcape6", "cdir"]
+    predictors: list[Union[str, Expression]] = ["cpr", "tp", "ws", "mxcape6", "cdir"]
     predictant: str = "tp"
     min_predictant: float = 0.04
     scale_outputs: Optional[float] = None

--- a/src/pproc/ecpoint.py
+++ b/src/pproc/ecpoint.py
@@ -363,7 +363,6 @@ def main():
                 total=cfg.total_fields,
             )
         ]
-        num_inputs = requesters[0].total
         dims = {k: set(val) for k, val in managers[0].dims.items()}
         static_data = earthkit.data.SimpleFieldList()
         for input_param in param.dependencies.values():
@@ -398,8 +397,7 @@ def main():
                 requesters.append(new_requester)
                 for k, val in new_manager.dims.items():
                     dims[k] |= set(val)
-            num_inputs += new_requester.total
-        logger.debug(f"Expected number of inputs: {num_inputs}")
+        logger.debug(f"Expected number of inputs: {param.num_inputs}")
         logger.debug(f"Dims: {dims}")
         ecpoint_partial = functools.partial(ecpoint_iteration, cfg, param, recover)
         input_sets = []
@@ -422,24 +420,31 @@ def main():
                                     "input_params": static_data,
                                 }
                             )
-                        new_field = earthkit.data.FieldList.from_array(
+                        new_fields = earthkit.data.FieldList.from_array(
                             completed_window.values, to_ekmetadata(param_metadata)
                         )
                         field_name = param_metadata[0]["shortName"]
-                        for input_set in input_sets:
-                            for metadata in param_metadata:
-                                field_name = metadata["shortName"]
+                        for field in new_fields:
+                            field_name = field.metadata()["shortName"]
+                            for input_set in input_sets:
                                 if (
                                     len(input_set["input_params"].sel(param=field_name))
                                     == 0
                                 ):
-                                    input_set["input_params"] += new_field
+                                    input_set[
+                                        "input_params"
+                                    ] += earthkit.data.FieldList.from_fields([field])
                     del ens
                 checked = 0
                 while checked < len(input_sets):
-                    if len(input_sets[checked]["input_params"]) == num_inputs:
+                    num_inputs = len(input_sets[checked]["input_params"])
+                    if num_inputs == param.num_inputs:
                         ecpoint_partial(**input_sets[checked])
                         del input_sets[checked]
+                    elif num_inputs >= param.num_inputs:
+                        raise ValueError(
+                            f"Retrieved {num_inputs} inputs, expected {param.num_inputs}"
+                        )
                     else:
                         checked += 1
 

--- a/src/pproc/ecpoint.py
+++ b/src/pproc/ecpoint.py
@@ -427,11 +427,13 @@ def main():
                         )
                         field_name = param_metadata[0]["shortName"]
                         for input_set in input_sets:
-                            if (
-                                len(input_set["input_params"].sel(param=field_name))
-                                == 0
-                            ):
-                                input_set["input_params"] += new_field
+                            for metadata in param_metadata:
+                                field_name = metadata["shortName"]
+                                if (
+                                    len(input_set["input_params"].sel(param=field_name))
+                                    == 0
+                                ):
+                                    input_set["input_params"] += new_field
                     del ens
                 checked = 0
                 while checked < len(input_sets):

--- a/src/pproc/ecpt/predictors.py
+++ b/src/pproc/ecpt/predictors.py
@@ -1,5 +1,6 @@
 import numpy as np
 import datetime
+import functools
 
 import eccodes
 import earthkit.data
@@ -11,6 +12,7 @@ from pproc.common.io import GribMetadata
 from pproc.common.param_requester import ParamRequester
 from pproc.config.param import ParamConfig
 from pproc.config.types import ECPointConfig
+from pproc.config.preprocessing import Expression
 
 
 def to_ekmetadata(metadata: list[GribMetadata]) -> list[StandAloneGribMetadata]:
@@ -22,15 +24,7 @@ def to_ekmetadata(metadata: list[GribMetadata]) -> list[StandAloneGribMetadata]:
     ]
 
 
-def _local_solar_time(hour: int, longitudes: np.ndarray) -> np.ndarray:
-    lst_pos = np.where(longitudes >= 0, hour + (longitudes / 15), 0)
-    temp_pos = np.where(lst_pos >= 24, lst_pos - 24, lst_pos)
-    lst_neg = np.where(longitudes < 0, hour - abs((longitudes / 15)), 0)
-    temp_neg = np.where(lst_neg < 0, lst_neg + 24, lst_neg)
-    return temp_pos + temp_neg
-
-
-def lst(
+def local_solar_time(
     config: ECPointConfig, param: ParamConfig, step_range: str, inputs: FieldList
 ) -> np.ndarray:
     tp = inputs.sel(param=config.predictant)
@@ -38,38 +32,61 @@ def lst(
     date_end = datetime.datetime.fromisoformat(tp[0].metadata("valid_datetime"))
     date_mid = date_end - datetime.timedelta(hours=(end - start) / 2)
     hour = date_mid.hour
-    lon = tp[0].metadata().geography.longitudes()
-    return _local_solar_time(hour, lon)
+    longitudes = tp[0].metadata().geography.longitudes()
+
+    lst_pos = np.where(longitudes >= 0, hour + (longitudes / 15), 0)
+    temp_pos = np.where(lst_pos >= 24, lst_pos - 24, lst_pos)
+    lst_neg = np.where(longitudes < 0, hour - abs((longitudes / 15)), 0)
+    temp_neg = np.where(lst_neg < 0, lst_neg + 24, lst_neg)
+    return temp_pos + temp_neg
 
 
-def ws(
-    config: ECPointConfig, param: ParamConfig, step_range: str, inputs: FieldList
+def wind_speed(
+    name: str,
+    config: ECPointConfig,
+    param: ParamConfig,
+    step_range: str,
+    inputs: FieldList,
 ) -> np.ndarray:
-    ws = inputs.sel(param="ws")
-    if len(ws) != 0:
-        return ws.values
-    return np.sqrt(
-        inputs.sel(param="u").values ** 2 + inputs.sel(param="v").values ** 2
-    )
+    components = {
+        "ws": ["u", "v"],
+        "10si": ["10u", "10v"],
+        "100si": ["100u", "100v"],
+        "200si": ["200u", "200v"],
+    }
+    u, v = components[name]
+    return np.sqrt(inputs.sel(param=u).values ** 2 + inputs.sel(param=v).values ** 2)
 
 
 def _ratio(var_num, var_den):
     den_zero = var_den == 0
     ratio_mapped = var_num / np.where(den_zero, -9999, var_den)
-    ratio = np.where(den_zero, 0, ratio_mapped)
+    return np.where(den_zero, 0, ratio_mapped)
+
+
+def cp_ratio(
+    config: ECPointConfig, param: ParamConfig, step_range: str, inputs: FieldList
+) -> np.ndarray:
+    ratio = _ratio(inputs.sel(param="cp").values, inputs.sel(param="tp").values)
     return np.where(ratio <= 1, ratio, 0)
 
 
-def cpr(
+def leaf_area_index(
     config: ECPointConfig, param: ParamConfig, step_range: str, inputs: FieldList
 ) -> np.ndarray:
-    return _ratio(inputs.sel(param="cp").values, inputs.sel(param="tp").values)
+    lai_h = inputs.sel(param="cvh").values * inputs.sel(param="lai_hv").values
+    lai_l = inputs.sel(param="cvl").values * inputs.sel(param="lai_lv").values
+    return lai_h + lai_l
 
 
 PREDICTORS = {
-    "lst": lst,
-    "ws": ws,
-    "cpr": cpr,
+    "local_solar_time": local_solar_time,
+    "ws": functools.partial(wind_speed, "ws"),
+    "10si": functools.partial(wind_speed, "10si"),
+    "100si": functools.partial(wind_speed, "100si"),
+    "200si": functools.partial(wind_speed, "200si"),
+    "cp_ratio": cp_ratio,
+    "lai": leaf_area_index,
 }
 
 
@@ -79,15 +96,20 @@ def compute_predictors(
     pred = []
     expected_shape = inputs.sel(param=config.predictant).values.shape
     for predictor in config.predictors:
-        if predictor in PREDICTORS:
-            pred_values = PREDICTORS[predictor](
-                config, param.dependencies.get(predictor, param), step_range, inputs
-            )
+        if isinstance(predictor, Expression):
+            pred_values = predictor.apply(inputs.metadata(), inputs.values)
         else:
             selected = inputs.sel(param=predictor)
-            if len(selected) == 0:
-                raise ValueError(f"No data found for predictor {predictor}")
-            pred_values = selected.values
+            if len(selected) != 0:
+                pred_values = selected.values
+            elif predictor in PREDICTORS:
+                pred_values = PREDICTORS[predictor](
+                    config, param.dependencies.get(predictor, param), step_range, inputs
+                )
+            else:
+                raise ValueError(
+                    f"No data or computation method found for predictor {predictor}"
+                )
         if pred_values.shape != expected_shape:
             pred_values = np.broadcast_to(pred_values, expected_shape)
         pred.append(pred_values)

--- a/src/pproc/ecpt/predictors.py
+++ b/src/pproc/ecpt/predictors.py
@@ -97,7 +97,10 @@ def compute_predictors(
     expected_shape = inputs.sel(param=config.predictant).values.shape
     for predictor in config.predictors:
         if isinstance(predictor, Expression):
-            pred_values = predictor.apply(inputs.metadata(), inputs.values)
+            _, output = predictor.apply(
+                [x.as_namespace("mars") for x in inputs.metadata()], inputs.values
+            )
+            pred_values = output[0]
         else:
             selected = inputs.sel(param=predictor)
             if len(selected) != 0:

--- a/src/pproc/ecpt/predictors.py
+++ b/src/pproc/ecpt/predictors.py
@@ -23,8 +23,15 @@ def to_ekmetadata(metadata: list[GribMetadata]) -> list[StandAloneGribMetadata]:
         for x in metadata
     ]
 
+def _local_solar_time(hour: int, longitudes: np.ndarray) -> np.ndarray:
+    lst_pos = np.where(longitudes >= 0, hour + (longitudes / 15), 0)
+    temp_pos = np.where(lst_pos >= 24, lst_pos - 24, lst_pos)
+    lst_neg = np.where(longitudes < 0, hour - abs((longitudes / 15)), 0)
+    temp_neg = np.where(lst_neg < 0, lst_neg + 24, lst_neg)
+    return temp_pos + temp_neg
 
-def local_solar_time(
+
+def lst(
     config: ECPointConfig, param: ParamConfig, step_range: str, inputs: FieldList
 ) -> np.ndarray:
     tp = inputs.sel(param=config.predictant)
@@ -32,13 +39,8 @@ def local_solar_time(
     date_end = datetime.datetime.fromisoformat(tp[0].metadata("valid_datetime"))
     date_mid = date_end - datetime.timedelta(hours=(end - start) / 2)
     hour = date_mid.hour
-    longitudes = tp[0].metadata().geography.longitudes()
-
-    lst_pos = np.where(longitudes >= 0, hour + (longitudes / 15), 0)
-    temp_pos = np.where(lst_pos >= 24, lst_pos - 24, lst_pos)
-    lst_neg = np.where(longitudes < 0, hour - abs((longitudes / 15)), 0)
-    temp_neg = np.where(lst_neg < 0, lst_neg + 24, lst_neg)
-    return temp_pos + temp_neg
+    lon = tp[0].metadata().geography.longitudes()
+    return _local_solar_time(hour, lon)
 
 
 def wind_speed(
@@ -80,7 +82,7 @@ def leaf_area_index(
 
 
 PREDICTORS = {
-    "local_solar_time": local_solar_time,
+    "local_solar_time": lst,
     "ws": functools.partial(wind_speed, "ws"),
     "10si": functools.partial(wind_speed, "10si"),
     "100si": functools.partial(wind_speed, "100si"),

--- a/tests/clusteps/test_season.py
+++ b/tests/clusteps/test_season.py
@@ -80,7 +80,7 @@ def test_season_dos(year):
     ids=id_tests,
 )
 def test_get_season(date, seasons, eseason):
-    config = SeasonConfig(seasons)
+    config = SeasonConfig(months=seasons)
     season = config.get_season(date)
     assert date in season
     assert season.name == eseason.name
@@ -116,7 +116,7 @@ def test_get_season(date, seasons, eseason):
     ids=id_tests,
 )
 def test_dos(date, seasons, edos):
-    config = SeasonConfig(seasons)
+    config = SeasonConfig(months=seasons)
     season = config.get_season(date)
     assert date in season
     assert season.dos(date) == edos

--- a/tests/common/test_accumulation.py
+++ b/tests/common/test_accumulation.py
@@ -308,6 +308,75 @@ def test_std_zero():
     np.testing.assert_almost_equal(acc.get_values(), np.zeros((2, 3)))
 
 
+@pytest.mark.parametrize(
+    "config, exp_values",
+    [
+        pytest.param(
+            {
+                "operation": "filter",
+                "filter_op": "max",
+                "filter_index": 0,
+                "coords": {"from": 1, "to": 3},
+                "sequential": True,
+            },
+            [
+                [[5.0, 9.0, 9.0], [3.0, 8.0, 18.0]],
+                [[1.0, 8.0, 27.0], [6.0, 24.0, 27.0]],
+            ],
+            id="filter-neighbours-0",
+        ),
+        pytest.param(
+            {
+                "operation": "filter",
+                "filter_op": "max",
+                "filter_index": 0,
+                "neighbours": [-1],
+                "neighbours_op": "mean",
+                "coords": {"from": 1, "to": 3},
+                "sequential": True,
+            },
+            [[[3.5, 5.0, 7.0], [2.5, 5.0, 11.5]], [[1.5, 6.0, 22.5], [5, 20.0, 40.5]]],
+            id="filter-neighbours-neg1",
+        ),
+        pytest.param(
+            {
+                "operation": "filter",
+                "filter_op": "min",
+                "filter_index": 0,
+                "neighbours": [1],
+                "neighbours_op": "mean",
+                "coords": {"from": 1, "to": 3},
+                "sequential": True,
+            },
+            [[[1.5, 5.0, 3.0], [1.5, 5.0, 3]], [[2.5, 6.0, 13.5], [3, 20.0, 67.5]]],
+            id="filter-neighbours-pos1",
+        ),
+    ],
+)
+def test_filter_accum(config, exp_values):
+    acc = create_accumulation(config)
+
+    step1 = np.array(
+        [[[5.0, 1.0, 1.0], [1.0, 4.0, 18.0]], [[1.0, 4.0, 9.0], [2.0, 8.0, 27.0]]]
+    )
+    step2 = np.array(
+        [[[2.0, 9.0, 5.0], [2.0, 2.0, 5.0]], [[2.0, 8.0, 18.0], [4.0, 16.0, 54.0]]]
+    )
+    step3 = np.array(
+        [[[1.0, 4.0, 9.0], [3.0, 8.0, 1.0]], [[3.0, 12.0, 27.0], [6.0, 24.0, 81.0]]]
+    )
+    for index, data in enumerate([step1, step2, step3]):
+        acc.feed(index + 1, data)
+    assert acc.is_complete()
+    np.testing.assert_almost_equal(acc.get_values(), exp_values)
+
+    acc.reset()
+    for index, data in enumerate([step1, step2, step3]):
+        acc.feed(index + 1, data)
+    assert acc.is_complete()
+    np.testing.assert_almost_equal(acc.get_values(), exp_values)
+
+
 def test_convert_dim():
     acc = Mean(range(25, 6))
     assert convert_dim(("step", acc)) == Dimension("step", acc)

--- a/tests/common/test_window.py
+++ b/tests/common/test_window.py
@@ -17,7 +17,6 @@ from pproc.common.window import legacy_window_factory, translate_window_config
 
 def create_window(
     coords: Union[list[Any], dict],
-    window_operation: str,
     include_start: bool,
     grib_keys: Optional[dict] = None,
     deaccumulate: bool = False,
@@ -25,7 +24,7 @@ def create_window(
     **extra,
 ) -> Union[Accumulation, Tuple[Accumulation, str]]:
     name, config = translate_window_config(
-        coords, window_operation, include_start, grib_keys, deaccumulate, **extra
+        coords, include_start, grib_keys, deaccumulate, **extra
     )
     acc = create_accumulation(config)
     if return_name:
@@ -34,7 +33,7 @@ def create_window(
 
 
 def test_instantaneous_window():
-    accum = create_window([1], "aggregation", True)
+    accum = create_window([1], include_start=True, operation="aggregation")
     step_values = np.array([[1, 1, 1], [2, 2, 2]])
     accum.feed(0, step_values)
     assert accum.get_values() is None
@@ -53,7 +52,7 @@ def test_instantaneous_window():
     ],
 )
 def test_simple_op(window_operation, values):
-    accum = create_window([0, 1, 2], window_operation, False)
+    accum = create_window([0, 1, 2], False, operation=window_operation)
     step_values = np.array([[1, 2, 3], [2, 4, 6]])
     accum.feed(0, step_values)
     accum.feed(1, step_values)
@@ -64,8 +63,8 @@ def test_simple_op(window_operation, values):
 
 
 def test_multi_windows():
-    accum = create_window([0, 1, 2], "sum", False)
-    accum2 = create_window([0, 1, 2], "sum", False)
+    accum = create_window([0, 1, 2], False, operation="sum")
+    accum2 = create_window([0, 1, 2], False, operation="sum")
     step_values = np.array([[1, 2, 3], [2, 4, 6]])
     accum.feed(1, step_values)
     accum2.feed(1, step_values)
@@ -86,7 +85,7 @@ def test_multi_windows():
         pytest.param("difference", True, [0, 2], 1, [[1, 2, 3], [2, 4, 6]], id="diff"),
         pytest.param(
             "weighted_mean",
-            False,
+            True,
             [0, 1, 2],
             1,
             [[1.5, 3, 4.5], [3, 6, 9]],
@@ -106,7 +105,7 @@ def test_multi_windows():
     ],
 )
 def test_windows(operation, include_init, steps, step_increment, values):
-    accum = create_window(steps, operation, include_init)
+    accum = create_window(steps, include_init, operation=operation)
     step_values = np.array([[1, 2, 3], [2, 4, 6]])
     accum.feed(0, step_values)
     accum.feed(step_increment, step_values)
@@ -156,7 +155,7 @@ def test_windows(operation, include_init, steps, step_increment, values):
     ],
 )
 def test_grib_header(steps, operation, extra_keys, grib_key_values):
-    accum = create_window(steps, operation, True, extra_keys)
+    accum = create_window(steps, True, extra_keys, operation=operation)
     header = accum.grib_keys()
     assert header == grib_key_values
 
@@ -169,7 +168,6 @@ def test_grib_header(steps, operation, extra_keys, grib_key_values):
             {"mars.expver": "0001"},
             {
                 f"{s}_0": {
-                    "operation": "aggregation",
                     "coords": [s],
                     "sequential": True,
                     "metadata": {
@@ -188,14 +186,12 @@ def test_grib_header(steps, operation, extra_keys, grib_key_values):
             {"timeRangeIndicator": 2},
             {
                 "0_0": {
-                    "operation": "aggregation",
                     "coords": [0],
                     "sequential": True,
                     "metadata": {"timeRangeIndicator": 2, "step": "0"},
                     "deaccumulate": False,
                 },
                 "0-3_0": {
-                    "operation": "aggregation",
                     "coords": [3],
                     "sequential": True,
                     "metadata": {
@@ -206,7 +202,6 @@ def test_grib_header(steps, operation, extra_keys, grib_key_values):
                     "deaccumulate": False,
                 },
                 "3-6_0": {
-                    "operation": "aggregation",
                     "coords": [6],
                     "sequential": True,
                     "metadata": {
@@ -217,7 +212,6 @@ def test_grib_header(steps, operation, extra_keys, grib_key_values):
                     "deaccumulate": False,
                 },
                 "300-306_0": {
-                    "operation": "aggregation",
                     "coords": [306],
                     "sequential": True,
                     "metadata": {
@@ -236,6 +230,7 @@ def test_grib_header(steps, operation, extra_keys, grib_key_values):
                 "windows": [
                     {
                         "operation": "difference",
+                        "include_start": True,
                         "coords": [
                             [a, b]
                             for a, b in [(90, 96), (93, 99), (96, 102), (270, 276)]
@@ -244,6 +239,7 @@ def test_grib_header(steps, operation, extra_keys, grib_key_values):
                     },
                     {
                         "operation": "difference",
+                        "include_start": True,
                         "coords": [
                             [a, b]
                             for a, b in [
@@ -509,6 +505,7 @@ def test_grib_header(steps, operation, extra_keys, grib_key_values):
             {
                 "windows": [
                     {
+                        "operation": "minimum",
                         "thresholds": [
                             {"comparison": "<=", "value": 273.15},
                         ],
@@ -553,6 +550,7 @@ def test_grib_header(steps, operation, extra_keys, grib_key_values):
             {
                 "windows": [
                     {
+                        "operation": "maximum",
                         "thresholds": [
                             {"comparison": ">=", "value": 15},
                             {"comparison": ">=", "value": 20},
@@ -602,6 +600,7 @@ def test_grib_header(steps, operation, extra_keys, grib_key_values):
                 "windows": [
                     {
                         "operation": "difference",
+                        "include_start": True,
                         "thresholds": [
                             {"comparison": ">=", "value": 0.001},
                             {"comparison": ">=", "value": 0.005},
@@ -620,6 +619,7 @@ def test_grib_header(steps, operation, extra_keys, grib_key_values):
                     },
                     {
                         "operation": "difference",
+                        "include_start": True,
                         "thresholds": [
                             {"comparison": ">=", "value": 0.025},
                             {"comparison": ">=", "value": 0.05},
@@ -637,6 +637,7 @@ def test_grib_header(steps, operation, extra_keys, grib_key_values):
                     },
                     {
                         "operation": "difference_rate",
+                        "include_start": True,
                         "factor": 1.0 / 24.0,
                         "thresholds": [
                             {"comparison": "<", "value": 0.001},
@@ -763,9 +764,17 @@ def test_grib_header(steps, operation, extra_keys, grib_key_values):
             {
                 "windows": [
                     {
+                        "operation": "minimum",
                         "thresholds": [
                             {"comparison": "<", "value": -8},
                             {"comparison": "<", "value": -4},
+                        ],
+                        "coords": [[0], [12], [360]],
+                        "metadata": {"bitsPerValue": 24},
+                    },
+                    {
+                        "operation": "maximum",
+                        "thresholds": [
                             {"comparison": ">", "value": 4},
                             {"comparison": ">", "value": 8},
                         ],
@@ -788,8 +797,19 @@ def test_grib_header(steps, operation, extra_keys, grib_key_values):
                 ],
                 "std_anomaly_windows": [
                     {
+                        "operation": "maximum",
                         "thresholds": [
                             {"comparison": ">", "value": 1},
+                        ],
+                        "coords": [[0], [12], [300]],
+                        "metadata": {
+                            "localDefinitionNumber": 30,
+                            "bitsPerValue": 24,
+                        },
+                    },
+                    {
+                        "operation": "minimum",
+                        "thresholds": [
                             {"comparison": "<", "value": -1.5},
                         ],
                         "coords": [[0], [12], [300]],
@@ -797,13 +817,13 @@ def test_grib_header(steps, operation, extra_keys, grib_key_values):
                             "localDefinitionNumber": 30,
                             "bitsPerValue": 24,
                         },
-                    }
+                    },
                 ],
             },
             {"type": "ep", "localDefinitionNumber": 5, "bitsPerValue": 8},
             {
                 **{
-                    f"{s}_{op}_0": {
+                    f"{s}_{index}": {
                         "operation": op,
                         "coords": [s],
                         "sequential": True,
@@ -819,14 +839,16 @@ def test_grib_header(steps, operation, extra_keys, grib_key_values):
                         },
                         "deaccumulate": False,
                     }
-                    for cmp, op, vals in [
-                        ("<", "minimum", [-8, -4]),
-                        (">", "maximum", [4, 8]),
-                    ]
+                    for index, (cmp, op, vals) in enumerate(
+                        [
+                            ("<", "minimum", [-8, -4]),
+                            (">", "maximum", [4, 8]),
+                        ]
+                    )
                     for s, tri in [(0, 1), (12, 0), (360, 10)]
                 },
                 **{
-                    f"{a}-{b}_1": {
+                    f"{a}-{b}_2": {
                         "operation": "mean",
                         "coords": list(range(a, b + 1, s)),
                         "sequential": True,
@@ -850,7 +872,7 @@ def test_grib_header(steps, operation, extra_keys, grib_key_values):
                     ]
                 },
                 **{
-                    f"std_{s}_{op}_0": {
+                    f"std_{s}_{index}": {
                         "operation": op,
                         "coords": [s],
                         "sequential": True,
@@ -864,10 +886,12 @@ def test_grib_header(steps, operation, extra_keys, grib_key_values):
                         },
                         "deaccumulate": False,
                     }
-                    for cmp, op, val in [
-                        (">", "maximum", 1),
-                        ("<", "minimum", -1.5),
-                    ]
+                    for index, (cmp, op, val) in enumerate(
+                        [
+                            (">", "maximum", 1),
+                            ("<", "minimum", -1.5),
+                        ]
+                    )
                     for s, tri in [(0, 1), (12, 0), (300, 10)]
                 },
             },

--- a/tests/prob/test_prob_accumulation_manager.py
+++ b/tests/prob/test_prob_accumulation_manager.py
@@ -28,6 +28,7 @@ from pproc.prob.accumulation_manager import (
                 "type": "legacywindow",
                 "windows": [
                     {
+                        "operation": "minimum",
                         "thresholds": [
                             {"comparison": "<=", "value": 273.15},
                         ],
@@ -55,6 +56,7 @@ from pproc.prob.accumulation_manager import (
                 "type": "legacywindow",
                 "windows": [
                     {
+                        "operation": "maximum",
                         "thresholds": [
                             {"comparison": ">=", "value": 15},
                             {"comparison": ">=", "value": 20},
@@ -88,6 +90,7 @@ from pproc.prob.accumulation_manager import (
                 "windows": [
                     {
                         "operation": "difference",
+                        "include_start": True,
                         "thresholds": [
                             {"comparison": ">=", "value": 0.001},
                             {"comparison": ">=", "value": 0.005},
@@ -98,6 +101,7 @@ from pproc.prob.accumulation_manager import (
                     },
                     {
                         "operation": "difference",
+                        "include_start": True,
                         "thresholds": [
                             {"comparison": ">=", "value": 0.025},
                             {"comparison": ">=", "value": 0.05},
@@ -107,6 +111,7 @@ from pproc.prob.accumulation_manager import (
                     },
                     {
                         "operation": "difference_rate",
+                        "include_start": True,
                         "factor": 1.0 / 24.0,
                         "thresholds": [
                             {"comparison": "<", "value": 0.001},
@@ -200,9 +205,16 @@ def test_create_threshold(config, expected, exp_coords):
                 "type": "legacywindow",
                 "windows": [
                     {
+                        "operation": "minimum",
                         "thresholds": [
                             {"comparison": "<", "value": -8},
                             {"comparison": "<", "value": -4},
+                        ],
+                        "coords": [[0], [12], [360]],
+                    },
+                    {
+                        "operation": "maximum",
+                        "thresholds": [
                             {"comparison": ">", "value": 4},
                             {"comparison": ">", "value": 8},
                         ],
@@ -223,28 +235,37 @@ def test_create_threshold(config, expected, exp_coords):
                 ],
                 "std_anomaly_windows": [
                     {
+                        "operation": "maximum",
                         "thresholds": [
                             {"comparison": ">", "value": 1},
+                        ],
+                        "coords": [[0], [12], [300]],
+                    },
+                    {
+                        "operation": "minimum",
+                        "thresholds": [
                             {"comparison": "<", "value": -1.5},
                         ],
                         "coords": [[0], [12], [300]],
-                    }
+                    },
                 ],
             },
             {
                 **{
-                    f"step_{s}_{op}_0": (
+                    f"step_{s}_{index}": (
                         SimpleAccumulation,
                         [{"comparison": cmp, "value": val} for val in vals],
                     )
-                    for cmp, op, vals in [
-                        ("<", "minimum", [-8, -4]),
-                        (">", "maximum", [4, 8]),
-                    ]
+                    for index, (cmp, op, vals) in enumerate(
+                        [
+                            ("<", "minimum", [-8, -4]),
+                            (">", "maximum", [4, 8]),
+                        ]
+                    )
                     for s in [0, 12, 360]
                 },
                 **{
-                    f"step_{a}-{b}_1": (
+                    f"step_{a}-{b}_2": (
                         Mean,
                         [
                             {"comparison": "<", "value": -4},
@@ -254,14 +275,16 @@ def test_create_threshold(config, expected, exp_coords):
                     for a, b in [(120, 240), (336, 360)]
                 },
                 **{
-                    f"step_std_{s}_{op}_0": (
+                    f"step_std_{s}_{index}": (
                         SimpleAccumulation,
                         [{"comparison": cmp, "value": val}],
                     )
-                    for cmp, op, val in [
-                        (">", "maximum", 1),
-                        ("<", "minimum", -1.5),
-                    ]
+                    for index, (cmp, op, val) in enumerate(
+                        [
+                            (">", "maximum", 1),
+                            ("<", "minimum", -1.5),
+                        ]
+                    )
                     for s in [0, 12, 300]
                 },
             },

--- a/tests/templates/prob.yaml
+++ b/tests/templates/prob.yaml
@@ -13,6 +13,7 @@ parameters:
         type: legacywindow
         windows:
         - coords: [[12], [12, 24, 36]]
+          operation: minimum
           thresholds:
           - comparison: <=
             local_scale_factor: 2

--- a/tests/templates/t850.yaml
+++ b/tests/templates/t850.yaml
@@ -26,18 +26,24 @@ parameters:
         type: legacywindow
         windows:
         - coords: [[0], [12]]
+          operation: minimum
           thresholds:
           - out_paramid: 131022
             comparison: <
             value: -8
+          metadata:
+            bitsPerValue: 24
+        - coords: [[0], [12]]
+          operation: maximum
+          thresholds:
           - out_paramid: 131025
             comparison: '>'
             value: 8
           metadata:
             bitsPerValue: 24
         - coords: [[0, 12, 24]]
-          window_operation: mean
-          include_start_step: true
+          operation: mean
+          include_start: true
           thresholds:
           - out_paramid: 131020
             comparison: <
@@ -49,10 +55,27 @@ parameters:
             bitsPerValue: 24
         std_anomaly_windows:
         - coords: [[0], [12]]
+          operation: maximum
           thresholds:
           - out_paramid: 133093
             comparison: '>'
             value: 1
+          metadata:
+            localDefinitionNumber: 30
+            bitsPerValue: 24
+            edition: 2
+            tablesVersion: 30
+            typeOfGeneratingProcess: 5
+            paramId: 0
+            timeIncrement: 12
+            # indicatorOfUnitForTimeIncrement: 1 ** Must be omitted when run with pytest **
+            typeOfStatisticalProcessing: 10
+            packingType: grid_ccsds
+            scaleFactorOfUpperLimit: MISSING
+            scaledValueOfUpperLimit: MISSING
+        - coords: [[0], [12]]
+          operation: minimum
+          thresholds:
           - out_paramid: 133096
             comparison: <
             value: -1

--- a/tests/test_products.py
+++ b/tests/test_products.py
@@ -111,7 +111,7 @@ TEST_DIR = os.path.dirname(os.path.realpath(__file__))
                     261016,
                     261018,
                     261015,
-                    261022,
+                    261023,
                     261014,
                     260242,
                 ],


### PR DESCRIPTION
### Description
- New accumulation type `Filter` which enables extraction of parameter values in a time range at the steps when one of the parameters is maximum or minimum. There is an additional option to combine neighbouring time steps from the maximum/minimum
- Generalised predictors in ecpoint to allow computation of other wind speeds and general expressions. Some predictor names were changed to differentiate from existing parameter names 
- Simplified legacy window translation, removing the determination of operation from thresholds and assumptions on `include_start` based on operation. Both `operation` and `include_start` must be specified to override the default behaviour

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 