### PR TITLE
Separate setting of `bitsPerValue` 

### DIFF
--- a/src/pproc/accum/postprocess.py
+++ b/src/pproc/accum/postprocess.py
@@ -70,6 +70,9 @@ def postprocess(
             template = metadata[0]
         else:
             template = metadata[i]
+        print("CONSTRUCT MESSAGE")
         message = construct_message(template, grib_keys)
+        print("SET ARRAY")
         message.set_array("values", nan_to_missing(message, field))
+        print("TARGET WRITE")
         target.write(message)

--- a/src/pproc/accum/postprocess.py
+++ b/src/pproc/accum/postprocess.py
@@ -69,4 +69,4 @@ def postprocess(
             template = metadata[0]
         else:
             template = metadata[i]
-        write_grib(target, message, field, grib_keys)
+        write_grib(target, template, field, grib_keys)

--- a/src/pproc/accum/postprocess.py
+++ b/src/pproc/accum/postprocess.py
@@ -70,7 +70,7 @@ def postprocess(
             template = metadata[0]
         else:
             template = metadata[i]
-        print("CONSTRUCT MESSAGE")
+        print("CONSTRUCT MESSAGE", grib_keys)
         message = construct_message(template, grib_keys)
         print("SET ARRAY")
         message.set_array("values", nan_to_missing(message, field))

--- a/src/pproc/accum/postprocess.py
+++ b/src/pproc/accum/postprocess.py
@@ -13,8 +13,7 @@ import numpy as np
 import eccodes
 
 from pproc.config.targets import Target
-from pproc.common.io import nan_to_missing
-from pproc.common.grib_helpers import construct_message
+from pproc.common.io import write_grib
 
 
 def postprocess(
@@ -70,9 +69,4 @@ def postprocess(
             template = metadata[0]
         else:
             template = metadata[i]
-        print("CONSTRUCT MESSAGE", grib_keys)
-        message = construct_message(template, grib_keys)
-        print("SET ARRAY")
-        message.set_array("values", nan_to_missing(message, field))
-        print("TARGET WRITE")
-        target.write(message)
+        write_grib(target, message, field, grib_keys)

--- a/src/pproc/anomaly.py
+++ b/src/pproc/anomaly.py
@@ -18,8 +18,7 @@ from conflator import Conflator
 
 from pproc.common.accumulation import Accumulator
 from pproc.common.accumulation_manager import AccumulationManager
-from pproc.common.grib_helpers import construct_message
-from pproc.common.io import nan_to_missing
+from pproc.common.io import write_grib
 from pproc.common.parallel import (
     create_executor,
     parallel_data_retrieval,
@@ -65,29 +64,29 @@ def anomaly_iteration(
 
         # Anomaly for each ensemble member
         for index, member in enumerate(ens):
-            message = construct_message(
+            anom = member - clim[0]
+            write_grib(
+                config.outputs.ens.target,
                 template,
+                anom,
                 {
                     **accum.grib_keys(),
                     **config.outputs.ens.metadata,
                     "number": index,
                 },
             )
-            anom = member - clim[0]
-            message.set_array("values", nan_to_missing(message, anom))
-            config.outputs.ens.target.write(message)
 
         # Anomaly for ensemble mean
         ensm_anom = np.mean(ens, axis=0) - clim[0]
-        message = construct_message(
+        write_grib(
+            config.outputs.ensm.target,
             template,
+            ensm_anom,
             {
                 **accum.grib_keys(),
                 **config.outputs.ensm.metadata,
             },
         )
-        message.set_array("values", nan_to_missing(message, ensm_anom))
-        config.outputs.ensm.target.write(message)
 
     config.outputs.ens.target.flush()
     config.outputs.ensm.target.flush()

--- a/src/pproc/common/grib_helpers.py
+++ b/src/pproc/common/grib_helpers.py
@@ -8,6 +8,7 @@
 # nor does it submit to any jurisdiction.
 
 from typing import Dict
+import numpy as np
 import re
 
 
@@ -17,7 +18,7 @@ def construct_message(template_grib, metadata: dict):
     arr_grib_keys = {
         key: value
         for key, value in metadata.items()
-        if not isinstance(value, (int, str, float))
+        if np.ndim(value) > 0
     }
     for arr_key in arr_grib_keys.keys():
         key_values.pop(arr_key)

--- a/src/pproc/common/grib_helpers.py
+++ b/src/pproc/common/grib_helpers.py
@@ -11,18 +11,16 @@ from typing import Dict
 import re
 
 
-def construct_message(template_grib, window_grib_headers: Dict):
-    """
-    Sets grib headers into template message using headers specified in
-    config, from the threshold and climatology date period
-    """
+def construct_message(template_grib, metadata: dict):
     out_grib = template_grib.copy()
-    key_values = window_grib_headers.copy()
-    set_missing = [
-        key for key, value in window_grib_headers.items() if value == "MISSING"
-    ]
-    for missing_key in set_missing:
-        key_values.pop(missing_key)
+    key_values = metadata.copy()
+    arr_grib_keys = {
+        key: value
+        for key, value in metadata.items()
+        if not isinstance(value, (int, str, float))
+    }
+    for arr_key in arr_grib_keys.keys():
+        key_values.pop(arr_key)
 
     template_edition = out_grib.get("edition")
     if key_values.get("edition", template_edition) == 2:
@@ -43,8 +41,8 @@ def construct_message(template_grib, window_grib_headers: Dict):
     else:
         out_grib.set(key_values, check_values=True)
 
-    for missing_key in set_missing:
-        out_grib.set_missing(missing_key)
+    for key, value in arr_grib_keys.items():
+        out_grib.set_array(key, value)
     return out_grib
 
 

--- a/src/pproc/common/grib_helpers.py
+++ b/src/pproc/common/grib_helpers.py
@@ -16,9 +16,7 @@ def construct_message(template_grib, metadata: dict):
     out_grib = template_grib.copy()
     key_values = metadata.copy()
     arr_grib_keys = {
-        key: value
-        for key, value in metadata.items()
-        if np.ndim(value) > 0
+        key: value for key, value in metadata.items() if np.ndim(value) > 0
     }
     for arr_key in arr_grib_keys.keys():
         key_values.pop(arr_key)

--- a/src/pproc/common/io.py
+++ b/src/pproc/common/io.py
@@ -357,8 +357,7 @@ def write_grib(target, template, data, metadata: dict, missing=None):
     
     data = nan_to_missing(message, data, missing)
     message.set_array("values", data)
-    if bits_per_value is not None:
-        message.set("setBitsPerValue", bits_per_value)
+    message.set("setBitsPerValue", bits_per_value)
 
     if np.isnan(data).any():
         n_missing1 = len(data[data == missing])

--- a/src/pproc/common/io.py
+++ b/src/pproc/common/io.py
@@ -348,11 +348,12 @@ def target_factory(target_option, out_file=None, fdb=None, overrides=None):
 
 
 def write_grib(target, template, data, metadata: dict, missing=None):
-    metadata = metadata.copy()
+    out_keys = {}
     if hasattr(template, "extra"):
-        metadata.update(template.extra)
-    bits_per_value = metadata.pop("bitsPerValue")
-    message = construct_message(template, metadata)
+        out_keys.update(template.extra)
+    out_keys.update(metadata)
+    bits_per_value = out_keys.pop("bitsPerValue")
+    message = construct_message(template, out_keys)
     
     data = nan_to_missing(message, data, missing)
     message.set_array("values", data)

--- a/src/pproc/common/io.py
+++ b/src/pproc/common/io.py
@@ -355,8 +355,8 @@ def write_grib(target, template, data, metadata: dict, missing=None):
     bits_per_value = out_keys.pop("bitsPerValue")
     message = construct_message(template, out_keys)
     
-    message.set("bitsPerValue", bits_per_value)
     data = nan_to_missing(message, data, missing)
+    message.set("bitsPerValue", bits_per_value)
     message.set_array("values", data)
 
     if np.isnan(data).any():

--- a/src/pproc/common/io.py
+++ b/src/pproc/common/io.py
@@ -352,11 +352,7 @@ def write_grib(target, template, data, metadata: dict, missing=None):
     if hasattr(template, "extra"):
         out_keys.update(template.extra)
     out_keys.update(metadata)
-    bits_per_value = (
-        out_keys.pop("bitsPerValue")
-        if template["bitsPerValue"] == 0
-        else template["bitsPerValue"]
-    )
+    bits_per_value = out_keys.pop("bitsPerValue")
     message = construct_message(template, out_keys)
     
     data = nan_to_missing(message, data, missing)
@@ -412,6 +408,15 @@ class GribMetadata(eccodes.Message):
         state["_handle"] = eccodes.MemoryReader(state["_handle"])._next_handle()
         self.__dict__.update(state)
 
+    def set(self, *args, check_values: bool = True):
+        super().set(*args, check_values=check_values)
+        if isinstance(args[0], dict):
+            for key in self.extra.keys():
+                if key in args[0]:
+                    self.extra[key] = args[0][key]
+        elif args[0] in self.extra:
+            self.extra[args[0]] = args[1]
+        
     def copy(self) -> Self:
         """Create a copy of the current message"""
         clone = self.__class__(eccodes.codes_clone(self._handle))

--- a/src/pproc/common/io.py
+++ b/src/pproc/common/io.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from io import BytesIO
 import os
 from typing import Optional, Union, List, Dict, Any
+from typing_extensions import Self
 
 import numpy as np
 import xarray as xr
@@ -28,6 +29,7 @@ from pproc.config.targets import (
     OverrideTargetWrapper,
 )
 from pproc.config.io import split_location
+from pproc.common.grib_helpers import construct_message
 
 
 @dataclass
@@ -345,21 +347,19 @@ def target_factory(target_option, out_file=None, fdb=None, overrides=None):
     return target
 
 
-def write_grib(target, template, data, missing=-9999):
-
-    message = template.copy()
-
-    # replace missing values if any
-    is_missing = np.isnan(data).any()
-    if is_missing:
-        data[np.isnan(data)] = missing
-        message.set("missingValue", missing)
-        message.set("bitmapPresent", 1)
-        message.set("bitsPerValue", template.get("bitsPerValue"))
-
+def write_grib(target, template, data, metadata: dict, missing=None):
+    metadata = metadata.copy()
+    if hasattr(template, "extra"):
+        metadata.update(template.extra)
+    bits_per_value = metadata.pop("bitsPerValue")
+    message = construct_message(template, metadata)
+    
     message.set_array("values", data)
+    nan_to_missing(message, data, missing)
+    if bits_per_value is not None:
+        message.set("bitsPerValue", bits_per_value)
 
-    if is_missing:
+    if np.isnan(data).any():
         n_missing1 = len(data[data == missing])
         n_missing2 = message.get("numberOfMissing")
         if n_missing1 != n_missing2:
@@ -397,15 +397,19 @@ def target_from_location(
 class GribMetadata(eccodes.Message):
     def __init__(self, handle, headers_only: bool = False):
         new_handle = eccodes.codes_clone(handle, headers_only=headers_only)
+        self.extra = {"bitsPerValue": eccodes.codes_get(handle, "bitsPerValue", int)}
         super().__init__(new_handle)
-        self.set({"edition": 2, "bitsPerValue": 24, "packingType": "grid_ccsds"})
 
     def __getstate__(self) -> dict:
-        ret = {"_handle": self.get_buffer()}
-        print("GET STATE")
+        ret = {"_handle": self.get_buffer(), "extra": self.extra}
         return ret
 
     def __setstate__(self, state: dict):
         state["_handle"] = eccodes.MemoryReader(state["_handle"])._next_handle()
         self.__dict__.update(state)
-        print("SET STATE")
+
+    def copy(self) -> Self:
+        """Create a copy of the current message"""
+        clone = self.__class__(eccodes.codes_clone(self._handle))
+        clone.extra = self.extra
+        return clone

--- a/src/pproc/common/io.py
+++ b/src/pproc/common/io.py
@@ -398,6 +398,7 @@ class GribMetadata(eccodes.Message):
     def __init__(self, handle, headers_only: bool = False):
         new_handle = eccodes.codes_clone(handle, headers_only=headers_only)
         super().__init__(new_handle)
+        self.set("packingType", "grid_ccsds")
 
     def __getstate__(self) -> dict:
         ret = {"_handle": self.get_buffer()}

--- a/src/pproc/common/io.py
+++ b/src/pproc/common/io.py
@@ -420,5 +420,5 @@ class GribMetadata(eccodes.Message):
     def copy(self) -> Self:
         """Create a copy of the current message"""
         clone = self.__class__(eccodes.codes_clone(self._handle))
-        clone.extra = self.extra
+        clone.extra = self.extra.copy()
         return clone

--- a/src/pproc/common/io.py
+++ b/src/pproc/common/io.py
@@ -352,9 +352,11 @@ def write_grib(target, template, data, metadata: dict, missing=None):
     if hasattr(template, "extra"):
         out_keys.update(template.extra)
     out_keys.update(metadata)
-    bits_per_value = out_keys.pop("bitsPerValue", template["bitsPerValue"])
-    if bits_per_value == 0:
-        raise ValueError("Can not set bitsPerValue to 0")
+    bits_per_value = (
+        out_keys.pop("bitsPerValue")
+        if template["bitsPerValue"] == 0
+        else template["bitsPerValue"]
+    )
     message = construct_message(template, out_keys)
     
     data = nan_to_missing(message, data, missing)

--- a/src/pproc/common/io.py
+++ b/src/pproc/common/io.py
@@ -354,8 +354,8 @@ def write_grib(target, template, data, metadata: dict, missing=None):
     bits_per_value = metadata.pop("bitsPerValue")
     message = construct_message(template, metadata)
     
+    data = nan_to_missing(message, data, missing)
     message.set_array("values", data)
-    nan_to_missing(message, data, missing)
     if bits_per_value is not None:
         message.set("bitsPerValue", bits_per_value)
 

--- a/src/pproc/common/io.py
+++ b/src/pproc/common/io.py
@@ -398,12 +398,14 @@ class GribMetadata(eccodes.Message):
     def __init__(self, handle, headers_only: bool = False):
         new_handle = eccodes.codes_clone(handle, headers_only=headers_only)
         super().__init__(new_handle)
-        self.set("packingType", "grid_ccsds")
+        self.set({"edition": 2, "bitsPerValue": 24, "packingType": "grid_ccsds"})
 
     def __getstate__(self) -> dict:
         ret = {"_handle": self.get_buffer()}
+        print("GET STATE")
         return ret
 
     def __setstate__(self, state: dict):
         state["_handle"] = eccodes.MemoryReader(state["_handle"])._next_handle()
         self.__dict__.update(state)
+        print("SET STATE")

--- a/src/pproc/common/io.py
+++ b/src/pproc/common/io.py
@@ -355,9 +355,9 @@ def write_grib(target, template, data, metadata: dict, missing=None):
     bits_per_value = out_keys.pop("bitsPerValue")
     message = construct_message(template, out_keys)
     
+    message.set("bitsPerValue", bits_per_value)
     data = nan_to_missing(message, data, missing)
     message.set_array("values", data)
-    message.set("setBitsPerValue", bits_per_value)
 
     if np.isnan(data).any():
         n_missing1 = len(data[data == missing])

--- a/src/pproc/common/io.py
+++ b/src/pproc/common/io.py
@@ -358,7 +358,7 @@ def write_grib(target, template, data, metadata: dict, missing=None):
     data = nan_to_missing(message, data, missing)
     message.set_array("values", data)
     if bits_per_value is not None:
-        message.set("bitsPerValue", bits_per_value)
+        message.set("setBitsPerValue", bits_per_value)
 
     if np.isnan(data).any():
         n_missing1 = len(data[data == missing])

--- a/src/pproc/common/io.py
+++ b/src/pproc/common/io.py
@@ -352,7 +352,9 @@ def write_grib(target, template, data, metadata: dict, missing=None):
     if hasattr(template, "extra"):
         out_keys.update(template.extra)
     out_keys.update(metadata)
-    bits_per_value = out_keys.pop("bitsPerValue")
+    bits_per_value = out_keys.pop("bitsPerValue", template["bitsPerValue"])
+    if bits_per_value == 0:
+        raise ValueError("Can not set bitsPerValue to 0")
     message = construct_message(template, out_keys)
     
     data = nan_to_missing(message, data, missing)

--- a/src/pproc/common/param_requester.py
+++ b/src/pproc/common/param_requester.py
@@ -65,6 +65,7 @@ def read_ensemble(
                 data = np.empty((total, message.get("numberOfDataPoints")), dtype=dtype)
             for message in reader:
                 i = n_read if index_func is None else index_func(message)
+                message.set("packingType", "grid_ccsds")
                 templates[i] = GribMetadata(message._handle, headers_only=True)
                 data[i, :] = missing_to_nan(message)
                 n_read += 1

--- a/src/pproc/common/param_requester.py
+++ b/src/pproc/common/param_requester.py
@@ -65,7 +65,6 @@ def read_ensemble(
                 data = np.empty((total, message.get("numberOfDataPoints")), dtype=dtype)
             for message in reader:
                 i = n_read if index_func is None else index_func(message)
-                message.set("packingType", "grid_ccsds")
                 templates[i] = GribMetadata(message._handle, headers_only=True)
                 data[i, :] = missing_to_nan(message)
                 n_read += 1

--- a/src/pproc/common/param_requester.py
+++ b/src/pproc/common/param_requester.py
@@ -65,7 +65,7 @@ def read_ensemble(
                 data = np.empty((total, message.get("numberOfDataPoints")), dtype=dtype)
             for message in reader:
                 i = n_read if index_func is None else index_func(message)
-                templates[i] = GribMetadata(message._handle)
+                templates[i] = GribMetadata(message._handle, headers_only=True)
                 data[i, :] = missing_to_nan(message)
                 n_read += 1
     if n_read != total:

--- a/src/pproc/common/param_requester.py
+++ b/src/pproc/common/param_requester.py
@@ -65,7 +65,7 @@ def read_ensemble(
                 data = np.empty((total, message.get("numberOfDataPoints")), dtype=dtype)
             for message in reader:
                 i = n_read if index_func is None else index_func(message)
-                templates[i] = GribMetadata(message._handle, headers_only=True)
+                templates[i] = message
                 data[i, :] = missing_to_nan(message)
                 n_read += 1
     if n_read != total:

--- a/src/pproc/common/param_requester.py
+++ b/src/pproc/common/param_requester.py
@@ -65,7 +65,7 @@ def read_ensemble(
                 data = np.empty((total, message.get("numberOfDataPoints")), dtype=dtype)
             for message in reader:
                 i = n_read if index_func is None else index_func(message)
-                templates[i] = message
+                templates[i] = GribMetadata(message._handle)
                 data[i, :] = missing_to_nan(message)
                 n_read += 1
     if n_read != total:

--- a/src/pproc/ecpoint.py
+++ b/src/pproc/ecpoint.py
@@ -32,9 +32,8 @@ from pproc.common.parallel import (
     parallel_data_retrieval,
     sigterm_handler,
 )
-from pproc.common.io import nan_to_missing, GribMetadata
+from pproc.common.io import write_grib, GribMetadata
 from pproc.common.accumulation_manager import AccumulationManager
-from pproc.common.grib_helpers import construct_message
 from pproc.quantile.grib import quantiles_template
 from pproc.ecpt.predictors import compute_predictors, to_ekmetadata
 
@@ -64,7 +63,7 @@ class FilteredParamRequester(ParamRequester):
 
 def grid_bc_template(
     template: eccodes.GRIBMessage, out_keys: dict
-) -> eccodes.GRIBMessage:
+) -> tuple[eccodes.GRIBMessage, dict]:
     edition = out_keys.get("edition", template.get("edition"))
     if edition not in (1, 2):
         raise ValueError(f"Unsupported GRIB edition {edition}")
@@ -83,12 +82,12 @@ def grid_bc_template(
                 "timeIncrement": 1,
             }
         )
-    return construct_message(template, grib_keys)
+    return template, grib_keys
 
 
 def weather_types_template(
     template: eccodes.GRIBMessage, out_keys: dict
-) -> eccodes.GRIBMessage:
+) -> tuple[eccodes.GRIBMessage, dict]:
     edition = out_keys.get("edition", template.get("edition"))
     if edition not in (1, 2):
         raise ValueError(f"Unsupported GRIB edition {edition}")
@@ -112,12 +111,12 @@ def weather_types_template(
                 "timeIncrement": 1,
             }
         )
-    return construct_message(template, grib_keys)
+    return template, grib_keys
 
 
 def point_scale_template(
     template: eccodes.GRIBMessage, pert_number: int, total_number: int, out_keys: dict
-) -> eccodes.GRIBMessage:
+) -> tuple[eccodes.GRIBMessage, dict]:
     edition = out_keys.get("edition", template.get("edition"))
     if edition not in (1, 2):
         raise ValueError(f"Unsupported GRIB edition {edition}")
@@ -289,24 +288,20 @@ def ecpoint_iteration(
     out_wt = config.outputs.wt
     for index, field in enumerate(input_params.sel(param=config.predictant)):
         template = field.metadata()._handle
-        bs_message = grid_bc_template(
+        bs_message, metadata = grid_bc_template(
             template,
             {
                 **out_keys,
                 **out_bs.metadata,
             },
         )
-        bs_message.set_array(
-            "values", nan_to_missing(bs_message, grid_bc_allens_allwt[index])
-        )
-        out_bs.target.write(bs_message)
+        write_grib(out_bs.target, bs_message, grid_bc_allens_allwt[index], metadata)
         out_bs.target.flush()
 
-        wt_message = weather_types_template(template, {**out_keys, **out_wt.metadata})
-        wt_message.set_array(
-            "values", nan_to_missing(wt_message, wt_allens_allwt[index])
+        wt_message, metadata = weather_types_template(
+            template, {**out_keys, **out_wt.metadata}
         )
-        out_wt.target.write(wt_message)
+        write_grib(out_wt.target, wt_message, wt_allens_allwt[index], metadata)
         out_wt.target.flush()
 
     del grid_bc_allens_allwt
@@ -325,11 +320,10 @@ def ecpoint_iteration(
                 **out_perc.metadata,
             }
             pert_number, total_number = config.quantile_indices(i)
-            message = point_scale_template(
+            message, metadata = point_scale_template(
                 template, pert_number, total_number, grib_keys
             )
-            message.set_array("values", nan_to_missing(message, quantile))
-            out_perc.target.write(message)
+            write_grib(out_perc.target, message, quantile, metadata)
         out_perc.target.flush()
 
     recovery.add_checkpoint(param=param.name, window=window_id)

--- a/src/pproc/ecpoint.py
+++ b/src/pproc/ecpoint.py
@@ -34,7 +34,7 @@ from pproc.common.parallel import (
 )
 from pproc.common.io import write_grib, GribMetadata
 from pproc.common.accumulation_manager import AccumulationManager
-from pproc.quantile.grib import quantiles_template
+from pproc.quantile.grib import quantiles_metadata
 from pproc.ecpt.predictors import compute_predictors, to_ekmetadata
 
 logger = logging.getLogger(__name__)
@@ -61,7 +61,7 @@ class FilteredParamRequester(ParamRequester):
         return super().retrieve_data(step=step, **kwargs)
 
 
-def grid_bc_template(
+def grid_bc_metadata(
     template: eccodes.GRIBMessage, out_keys: dict
 ) -> tuple[eccodes.GRIBMessage, dict]:
     edition = out_keys.get("edition", template.get("edition"))
@@ -85,7 +85,7 @@ def grid_bc_template(
     return template, grib_keys
 
 
-def weather_types_template(
+def weather_types_metadata(
     template: eccodes.GRIBMessage, out_keys: dict
 ) -> tuple[eccodes.GRIBMessage, dict]:
     edition = out_keys.get("edition", template.get("edition"))
@@ -114,7 +114,7 @@ def weather_types_template(
     return template, grib_keys
 
 
-def point_scale_template(
+def point_scale_metadata(
     template: eccodes.GRIBMessage, pert_number: int, total_number: int, out_keys: dict
 ) -> dict:
     edition = out_keys.get("edition", template.get("edition"))
@@ -135,7 +135,7 @@ def point_scale_template(
                 "timeIncrement": 1,
             }
         )
-    return quantiles_template(template, pert_number, total_number, grib_keys)
+    return quantiles_metadata(template, pert_number, total_number, grib_keys)
 
 
 def compute_single_ens(
@@ -288,7 +288,7 @@ def ecpoint_iteration(
     out_wt = config.outputs.wt
     for index, field in enumerate(input_params.sel(param=config.predictant)):
         template = field.metadata()._handle
-        bs_message, metadata = grid_bc_template(
+        bs_message, metadata = grid_bc_metadata(
             template,
             {
                 **out_keys,
@@ -298,7 +298,7 @@ def ecpoint_iteration(
         write_grib(out_bs.target, bs_message, grid_bc_allens_allwt[index], metadata)
         out_bs.target.flush()
 
-        wt_message, metadata = weather_types_template(
+        wt_message, metadata = weather_types_metadata(
             template, {**out_keys, **out_wt.metadata}
         )
         write_grib(out_wt.target, wt_message, wt_allens_allwt[index], metadata)
@@ -320,7 +320,7 @@ def ecpoint_iteration(
                 **out_perc.metadata,
             }
             pert_number, total_number = config.quantile_indices(i)
-            metadata = point_scale_template(
+            metadata = point_scale_metadata(
                 template, pert_number, total_number, grib_keys
             )
             write_grib(out_perc.target, template, quantile, metadata)

--- a/src/pproc/ecpoint.py
+++ b/src/pproc/ecpoint.py
@@ -116,7 +116,7 @@ def weather_types_template(
 
 def point_scale_template(
     template: eccodes.GRIBMessage, pert_number: int, total_number: int, out_keys: dict
-) -> tuple[eccodes.GRIBMessage, dict]:
+) -> dict:
     edition = out_keys.get("edition", template.get("edition"))
     if edition not in (1, 2):
         raise ValueError(f"Unsupported GRIB edition {edition}")
@@ -320,10 +320,10 @@ def ecpoint_iteration(
                 **out_perc.metadata,
             }
             pert_number, total_number = config.quantile_indices(i)
-            message, metadata = point_scale_template(
+            metadata = point_scale_template(
                 template, pert_number, total_number, grib_keys
             )
-            write_grib(out_perc.target, message, quantile, metadata)
+            write_grib(out_perc.target, template, quantile, metadata)
         out_perc.target.flush()
 
     recovery.add_checkpoint(param=param.name, window=window_id)

--- a/src/pproc/ensms.py
+++ b/src/pproc/ensms.py
@@ -26,7 +26,7 @@ import numpy as np
 from conflator import Conflator
 from meters import ResourceMeter
 
-from pproc import common
+from pproc.common.io import write_grib
 from pproc.common.accumulation import Accumulator
 from pproc.common.accumulation_manager import AccumulationManager
 from pproc.common.parallel import (
@@ -40,20 +40,16 @@ from pproc.common.grib_helpers import fill_template_values
 from pproc.config.types import EnsmsConfig
 
 
-def template_ensemble(
-    template: eccodes.GRIBMessage,
+def ensms_metadata(
     accum: Accumulator,
     out_keys: dict,
 ):
-    template_ens = template.copy()
-
     grib_sets = accum.grib_keys().copy()
     grib_sets.update(out_keys)
     grib_sets = fill_template_values(
         grib_sets, {"num_fields": np.prod(accum.values.shape[:-1])}
     )
-    template_ens.set(grib_sets)
-    return template_ens
+    return grib_sets
 
 
 def ensms_iteration(
@@ -73,16 +69,19 @@ def ensms_iteration(
     with ResourceMeter(f"Window {window_id}: write mean output"):
         mean = np.mean(ens, axis=axes)
         out_mean = config.outputs.mean
-        template_mean = template_ensemble(template_ens, accum, out_mean.metadata)
-        template_mean.set_array("values", common.io.nan_to_missing(template_mean, mean))
-        out_mean.target.write(template_mean)
+        write_grib(
+            out_mean.target,
+            template_ens,
+            mean,
+            ensms_metadata(accum, out_mean.metadata),
+        )
 
     with ResourceMeter(f"Window {window_id}: write std output"):
         std = np.std(ens, axis=axes)
         out_std = config.outputs.std
-        template_std = template_ensemble(template_ens, accum, out_std.metadata)
-        template_std.set_array("values", common.io.nan_to_missing(template_std, std))
-        out_std.target.write(template_std)
+        write_grib(
+            out_std.target, template_ens, std, ensms_metadata(accum, out_std.metadata)
+        )
 
     out_mean.target.flush()
     out_std.target.flush()

--- a/src/pproc/extreme.py
+++ b/src/pproc/extreme.py
@@ -76,7 +76,7 @@ def compute_indices(
         clim, template_clim = read_clim(cfg, param.clim, accum)
         print(f"Climatology array: {clim.shape}")
 
-        template_extreme = extreme_template(
+        template_extreme, metadata = extreme_template(
             accum,
             message_template,
             template_clim,
@@ -91,9 +91,9 @@ def compute_indices(
 
         for name, index in param.indices.items():
             output = getattr(cfg.outputs, name)
-            template = template_extreme.copy()
-            template.set(output.metadata)
-            index.compute(clim, ens, output.target, message_template, template)
+            index.compute(
+                clim, ens, target, message_template, template_extreme, {metadata, **output.metadata}
+            )
             output.target.flush()
 
         recovery.add_checkpoint(param=param.name, window=window_id)

--- a/src/pproc/extreme.py
+++ b/src/pproc/extreme.py
@@ -92,7 +92,12 @@ def compute_indices(
         for name, index in param.indices.items():
             output = getattr(cfg.outputs, name)
             index.compute(
-                clim, ens, target, message_template, template_extreme, {metadata, **output.metadata}
+                clim,
+                ens,
+                target,
+                message_template,
+                template_extreme,
+                {**metadata, **output.metadata},
             )
             output.target.flush()
 

--- a/src/pproc/extreme.py
+++ b/src/pproc/extreme.py
@@ -94,7 +94,7 @@ def compute_indices(
             index.compute(
                 clim,
                 ens,
-                target,
+                output.target,
                 message_template,
                 template_extreme,
                 {**metadata, **output.metadata},

--- a/src/pproc/extremes/grib.py
+++ b/src/pproc/extremes/grib.py
@@ -135,7 +135,7 @@ def extreme_template(accum, template_fc, template_clim, allow_grib1_to_grib2=Fal
     return template_ext, grib_keys
 
 
-def efi_template(template, metadata) -> dict:
+def efi_metadata(template, metadata) -> dict:
     metadata = metadata.copy()
     metadata["marsType"] = 27
 
@@ -152,7 +152,7 @@ def efi_template(template, metadata) -> dict:
     return metadata
 
 
-def efi_template_control(template, metadata) -> dict:
+def efi_metadata_control(template, metadata) -> dict:
     metadata = metadata.copy()
     metadata["marsType"] = 28
 
@@ -170,7 +170,7 @@ def efi_template_control(template, metadata) -> dict:
     return metadata
 
 
-def sot_template(template, sot, metadata) -> dict:
+def sot_metadata(template, sot, metadata) -> dict:
     metadata = metadata.copy()
     metadata["marsType"] = 38
 
@@ -201,7 +201,7 @@ def sot_template(template, sot, metadata) -> dict:
     return metadata
 
 
-def cpf_template(template, metadata) -> dict:
+def cpf_metadata(template, metadata) -> dict:
     metadata = metadata.copy()
     metadata[
         "marsType"

--- a/src/pproc/extremes/grib.py
+++ b/src/pproc/extremes/grib.py
@@ -46,7 +46,9 @@ def extreme_template(accum, template_fc, template_clim, allow_grib1_to_grib2=Fal
         for key in fc_keys:
             grib_keys[key] = template_fc[key]
         total_number = template_fc.get("totalNumber", len(accum.values), int)
-        grib_keys["totalNumber"] = len(accum.values) if total_number == 0 else total_number
+        grib_keys["totalNumber"] = (
+            len(accum.values) if total_number == 0 else total_number
+        )
     elif edition == 2 and clim_edition == 2:
         clim_keys = [
             "typeOfReferenceDataset",
@@ -120,62 +122,57 @@ def extreme_template(accum, template_fc, template_clim, allow_grib1_to_grib2=Fal
                 "secondOfStartOfReferencePeriod": 0,
                 "sampleSizeOfReferencePeriod": clim_size,
                 "numberOfReferencePeriodTimeRanges": 2,
+                "typeOfStatisticalProcessingForTimeRangeForReferencePeriod": [20, 20],
+                "indicatorOfUnitForTimeRangeForReferencePeriod": [4, 2],
+                "lengthOfTimeRangeForReferencePeriod": [clim_nyears, clim_window],
             }
         )
-        template_ext.set(grib_keys)
-        arr_grib_keys = {
-            "typeOfStatisticalProcessingForTimeRangeForReferencePeriod": [20, 20],
-            "indicatorOfUnitForTimeRangeForReferencePeriod": [4, 2],
-            "lengthOfTimeRangeForReferencePeriod": [clim_nyears, clim_window],
-        }
-        for key, value in arr_grib_keys.items():
-            template_ext.set_array(key, value)
-        grib_keys = {}
     else:
         raise Exception(
             f"Unsupported GRIB edition {edition} and clim edition {clim_edition}"
         )
 
-    template_ext.set(grib_keys)
-    return template_ext
+    return template_ext, grib_keys
 
 
-def efi_template(template):
-    template_efi = template.copy()
-    template_efi["marsType"] = 27
+def efi_template(template, metadata) -> dict:
+    metadata = metadata.copy()
+    metadata["marsType"] = 27
 
-    edition = template_efi["edition"]
+    edition = metadata.get("edition", template["edition"])
     if edition == 1:
-        template_efi["efiOrder"] = 0
-        template_efi["number"] = 0
+        metadata["efiOrder"] = 0
+        metadata["number"] = 0
     elif edition == 2:
-        grib_set = {"typeOfRelationToReferenceDataset": 20, "typeOfProcessedData": 5}
-        template_efi.set(grib_set)
+        metadata.update(
+            {"typeOfRelationToReferenceDataset": 20, "typeOfProcessedData": 5}
+        )
     else:
         raise Exception(f"Unsupported GRIB edition {edition}")
-    return template_efi
+    return metadata
 
 
-def efi_template_control(template):
-    template_efi = template.copy()
-    template_efi["marsType"] = 28
+def efi_template_control(template, metadata) -> dict:
+    metadata = metadata.copy()
+    metadata["marsType"] = 28
 
-    edition = template_efi["edition"]
+    edition = metadata.get("edition", template["edition"])
     if edition == 1:
-        template_efi["efiOrder"] = 0
-        template_efi["totalNumber"] = 1
-        template_efi["number"] = 0
+        metadata["efiOrder"] = 0
+        metadata["totalNumber"] = 1
+        metadata["number"] = 0
     elif edition == 2:
-        grib_set = {"typeOfRelationToReferenceDataset": 20, "typeOfProcessedData": 3}
-        template_efi.set(grib_set)
+        metadata.update(
+            {"typeOfRelationToReferenceDataset": 20, "typeOfProcessedData": 3}
+        )
     else:
         raise Exception(f"Unsupported GRIB edition {edition}")
-    return template_efi
+    return metadata
 
 
-def sot_template(template, sot):
-    template_sot = template.copy()
-    template_sot["marsType"] = 38
+def sot_template(template, sot, metadata) -> dict:
+    metadata = metadata.copy()
+    metadata["marsType"] = 38
 
     if sot == 90:
         efi_order = 99
@@ -185,37 +182,39 @@ def sot_template(template, sot):
         raise Exception(
             f"SOT value '{sot}' not supported in template! Only accepting 10 and 90"
         )
-    edition = template_sot["edition"]
+    edition = metadata.get("edition", template["edition"])
     if edition == 1:
-        template_sot["number"] = sot
-        template_sot["efiOrder"] = efi_order
+        metadata["number"] = sot
+        metadata["efiOrder"] = efi_order
     elif edition == 2:
-        grib_set = {
-            "typeOfRelationToReferenceDataset": 21,
-            "typeOfProcessedData": 5,
-            "numberOfAdditionalParametersForReferencePeriod": 2,
-            "scaleFactorOfAdditionalParameterForReferencePeriod": [0, 0],
-            "scaledValueOfAdditionalParameterForReferencePeriod": [sot, efi_order],
-        }
-        template_sot.set(grib_set)
+        metadata.update(
+            {
+                "typeOfRelationToReferenceDataset": 21,
+                "typeOfProcessedData": 5,
+                "numberOfAdditionalParametersForReferencePeriod": 2,
+                "scaleFactorOfAdditionalParameterForReferencePeriod": [0, 0],
+                "scaledValueOfAdditionalParameterForReferencePeriod": [sot, efi_order],
+            }
+        )
     else:
         raise Exception(f"Unsupported GRIB edition {edition}")
-    return template_sot
+    return metadata
 
 
-def cpf_template(template):
-    template_cpf = template.copy()
-    template_cpf[
+def cpf_template(template, metadata) -> dict:
+    metadata = metadata.copy()
+    metadata[
         "marsType"
     ] = 27  # FIXME: this corresponds to efi, should be a new value for cpf
-    template_cpf["bitsPerValue"] = 24
+    metadata["bitsPerValue"] = 24
 
-    edition = template_cpf["edition"]
+    edition = metadata.get("edition", template["edition"])
     if edition == 1:
-        template_cpf["number"] = 0
+        metadata["number"] = 0
     elif edition == 2:
-        grib_set = {"typeOfRelationToReferenceDataset": 24, "typeOfProcessedData": 5}
-        template_cpf.set(grib_set)
+        metadata.update(
+            {"typeOfRelationToReferenceDataset": 24, "typeOfProcessedData": 5}
+        )
     else:
         raise Exception(f"Unsupported GRIB edition {edition}")
-    return template_cpf
+    return metadata

--- a/src/pproc/extremes/grib.py
+++ b/src/pproc/extremes/grib.py
@@ -122,11 +122,17 @@ def extreme_template(accum, template_fc, template_clim, allow_grib1_to_grib2=Fal
                 "secondOfStartOfReferencePeriod": 0,
                 "sampleSizeOfReferencePeriod": clim_size,
                 "numberOfReferencePeriodTimeRanges": 2,
-                "typeOfStatisticalProcessingForTimeRangeForReferencePeriod": [20, 20],
-                "indicatorOfUnitForTimeRangeForReferencePeriod": [4, 2],
-                "lengthOfTimeRangeForReferencePeriod": [clim_nyears, clim_window],
             }
         )
+        template_ext.set(grib_keys)
+        arr_grib_keys = {
+            "typeOfStatisticalProcessingForTimeRangeForReferencePeriod": [20, 20],
+            "indicatorOfUnitForTimeRangeForReferencePeriod": [4, 2],
+            "lengthOfTimeRangeForReferencePeriod": [clim_nyears, clim_window],
+        }
+        for key, value in arr_grib_keys.items():
+            template_ext.set_array(key, value)
+        grib_keys = {}
     else:
         raise Exception(
             f"Unsupported GRIB edition {edition} and clim edition {clim_edition}"

--- a/src/pproc/extremes/indices.py
+++ b/src/pproc/extremes/indices.py
@@ -36,6 +36,7 @@ class Index(metaclass=ABCMeta):
         target: Target,
         in_template: GRIBMessage,
         out_template: GRIBMessage,
+        metadata: dict,
     ):
         raise NotImplementedError
 
@@ -52,15 +53,16 @@ class EFI(Index):
         target: Target,
         in_template: GRIBMessage,
         out_template: GRIBMessage,
+        metadata: dict,
     ):
         if in_template.get("type") in ["cf", "fc"]:
             efi_control = extreme.efi(clim, ens[:1, :], self.eps)
-            template_efi = efi_template_control(out_template)
-            common.io.write_grib(target, template_efi, efi_control)
+            control_metadata = efi_template_control(out_template, metadata)
+            common.io.write_grib(target, out_template, efi_control, control_metadata)
 
         efi = extreme.efi(clim, ens, self.eps)
-        template_efi = efi_template(out_template)
-        common.io.write_grib(target, template_efi, efi)
+        efi_metadata = efi_template(out_template, metadata)
+        common.io.write_grib(target, out_template, efi, efi_metadata)
 
 
 class SOT(Index):
@@ -76,17 +78,22 @@ class SOT(Index):
         target: Target,
         in_template: GRIBMessage,
         out_template: GRIBMessage,
+        metadata: dict,
     ):
         for perc in self.sot:
             sot = extreme.sot(clim, ens, perc, self.eps)
-            template_sot = sot_template(out_template, perc)
-            common.io.write_grib(target, template_sot, sot)
+            sot_metadata = sot_template(out_template, perc, metadata)
+            common.io.write_grib(target, out_template, sot, sot_metadata)
 
 
 class CPF(Index):
     def __init__(self, options):
         super().__init__(options)
-        self.eps = float(options["cpf_eps"]) if options.get("cpf_eps", None) is not None else None
+        self.eps = (
+            float(options["cpf_eps"])
+            if options.get("cpf_eps", None) is not None
+            else None
+        )
         self.symmetric = options.get("cpf_symmetric", False)
 
     def compute(
@@ -96,6 +103,7 @@ class CPF(Index):
         target: Target,
         in_template: GRIBMessage,
         out_template: GRIBMessage,
+        metadata: dict,
     ):
         cpf = extreme.cpf(
             clim.astype(np.float32),
@@ -105,8 +113,8 @@ class CPF(Index):
             epsilon=self.eps,
             symmetric=self.symmetric,
         )
-        template_cpf = cpf_template(out_template)
-        common.io.write_grib(target, template_cpf, cpf)
+        cpf_metadata = cpf_template(out_template, metadata)
+        common.io.write_grib(target, out_template, cpf, cpf_metadata)
 
 
 _INDICES = {"efi": EFI, "sot": SOT, "cpf": CPF}

--- a/src/pproc/extremes/indices.py
+++ b/src/pproc/extremes/indices.py
@@ -17,10 +17,10 @@ import numpy as np
 from pproc import common
 from pproc.config.targets import Target
 from pproc.extremes.grib import (
-    cpf_template,
-    efi_template,
-    efi_template_control,
-    sot_template,
+    cpf_metadata,
+    efi_metadata,
+    efi_metadata_control,
+    sot_metadata,
 )
 
 
@@ -57,12 +57,12 @@ class EFI(Index):
     ):
         if in_template.get("type") in ["cf", "fc"]:
             efi_control = extreme.efi(clim, ens[:1, :], self.eps)
-            control_metadata = efi_template_control(out_template, metadata)
-            common.io.write_grib(target, out_template, efi_control, control_metadata)
+            control_keys = efi_metadata_control(out_template, metadata)
+            common.io.write_grib(target, out_template, efi_control, control_keys)
 
         efi = extreme.efi(clim, ens, self.eps)
-        efi_metadata = efi_template(out_template, metadata)
-        common.io.write_grib(target, out_template, efi, efi_metadata)
+        efi_keys = efi_metadata(out_template, metadata)
+        common.io.write_grib(target, out_template, efi, efi_keys)
 
 
 class SOT(Index):
@@ -82,8 +82,8 @@ class SOT(Index):
     ):
         for perc in self.sot:
             sot = extreme.sot(clim, ens, perc, self.eps)
-            sot_metadata = sot_template(out_template, perc, metadata)
-            common.io.write_grib(target, out_template, sot, sot_metadata)
+            sot_keys = sot_metadata(out_template, perc, metadata)
+            common.io.write_grib(target, out_template, sot, sot_keys)
 
 
 class CPF(Index):
@@ -113,8 +113,8 @@ class CPF(Index):
             epsilon=self.eps,
             symmetric=self.symmetric,
         )
-        cpf_metadata = cpf_template(out_template, metadata)
-        common.io.write_grib(target, out_template, cpf, cpf_metadata)
+        cpf_keys = cpf_metadata(out_template, metadata)
+        common.io.write_grib(target, out_template, cpf, cpf_keys)
 
 
 _INDICES = {"efi": EFI, "sot": SOT, "cpf": CPF}

--- a/src/pproc/histogram.py
+++ b/src/pproc/histogram.py
@@ -21,10 +21,9 @@ from conflator import Conflator
 from pproc.common.accumulation import Accumulator
 from pproc.common.accumulation_manager import AccumulationManager
 from pproc.common.dataset import open_multi_dataset
-from pproc.common.grib_helpers import construct_message, fill_template_values
 from pproc.common.io import (
     missing_to_nan,
-    nan_to_missing,
+    write_grib,
     GribMetadata,
 )
 from pproc.common.parallel import (
@@ -78,9 +77,7 @@ def write_histogram(
             "totalNumber": nbins,
             "perturbationNumber": i + 1,
         }
-        message = construct_message(template, grib_keys)
-        message.set_array("values", nan_to_missing(message, hist_bin))
-        target.write(message)
+        write_grib(target, template, hist_bin, grib_keys)
 
 
 def iter_ensemble(

--- a/src/pproc/prob/parallel.py
+++ b/src/pproc/prob/parallel.py
@@ -14,12 +14,11 @@ import numexpr
 
 import eccodes
 
-from pproc import common
 from pproc.config.param import ParamConfig
 from pproc.config.io import Output
 from pproc.common.recovery import BaseRecovery
 from pproc.common.accumulation import Accumulator
-from pproc.common.grib_helpers import construct_message
+from pproc.common.io import write_grib
 
 
 def threshold_grib_headers(
@@ -132,14 +131,7 @@ def prob_iteration(
                 )
             )
             grib_set.update(threshold.get("metadata", {}))
-            common.io.write_grib(
-                out_prob.target,
-                construct_message(
-                    template,
-                    grib_set,
-                ),
-                window_probability,
-            )
+            write_grib(out_prob.target, template, window_probability, grib_set)
 
         out_prob.target.flush()
         recovery.add_checkpoint(param=param.name, window=window_id)

--- a/src/pproc/quantile/grib.py
+++ b/src/pproc/quantile/grib.py
@@ -10,7 +10,7 @@
 import eccodes
 
 
-def quantiles_template(
+def quantiles_metadata(
     template: eccodes.GRIBMessage,
     pert_number: int,
     total_number: int,

--- a/src/pproc/quantile/grib.py
+++ b/src/pproc/quantile/grib.py
@@ -9,16 +9,13 @@
 
 import eccodes
 
-from pproc.common.grib_helpers import construct_message
-
 
 def quantiles_template(
     template: eccodes.GRIBMessage,
     pert_number: int,
     total_number: int,
     out_keys: dict,
-) -> eccodes.GRIBMessage:
-
+) -> dict:
     edition = out_keys.get("edition", template.get("edition"))
     if edition not in (1, 2):
         raise ValueError(f"Unsupported GRIB edition {edition}")
@@ -38,5 +35,4 @@ def quantiles_template(
                 "quantileValue": pert_number,
             }
         )
-    message = construct_message(template, grib_keys)
-    return message
+    return grib_keys

--- a/src/pproc/quantiles.py
+++ b/src/pproc/quantiles.py
@@ -31,7 +31,7 @@ from pproc.common.parallel import (
 from pproc.common.param_requester import ParamConfig, ParamRequester
 from pproc.common.recovery import create_recovery, BaseRecovery
 from pproc.config.types import QuantilesConfig
-from pproc.quantile.grib import quantiles_template
+from pproc.quantile.grib import quantiles_metadata
 
 
 def do_quantiles(
@@ -65,7 +65,7 @@ def do_quantiles(
         grib_keys = fill_template_values(
             out_keys.copy(), {"num_fields": np.prod(ens.shape[:-1])}
         )
-        metadata = quantiles_template(template, pert_number, total_number, grib_keys)
+        metadata = quantiles_metadata(template, pert_number, total_number, grib_keys)
         write_grib(config.outputs.quantiles.target, template, quantile, metadata)
 
 

--- a/src/pproc/quantiles.py
+++ b/src/pproc/quantiles.py
@@ -21,8 +21,8 @@ from conflator import Conflator
 
 from pproc.common.accumulation import Accumulator
 from pproc.common.accumulation_manager import AccumulationManager
-from pproc.common.grib_helpers import construct_message, fill_template_values
-from pproc.common.io import nan_to_missing
+from pproc.common.grib_helpers import fill_template_values
+from pproc.common.io import write_grib
 from pproc.common.parallel import (
     create_executor,
     parallel_data_retrieval,
@@ -65,9 +65,8 @@ def do_quantiles(
         grib_keys = fill_template_values(
             out_keys.copy(), {"num_fields": np.prod(ens.shape[:-1])}
         )
-        message = quantiles_template(template, pert_number, total_number, grib_keys)
-        message.set_array("values", nan_to_missing(message, quantile))
-        config.outputs.quantiles.target.write(message)
+        metadata = quantiles_template(template, pert_number, total_number, grib_keys)
+        write_grib(config.outputs.quantiles.target, template, quantile, metadata)
 
 
 def quantiles_iteration(

--- a/src/pproc/significance.py
+++ b/src/pproc/significance.py
@@ -21,8 +21,7 @@ from conflator import Conflator
 
 from pproc.common.accumulation import Accumulator
 from pproc.common.accumulation_manager import AccumulationManager
-from pproc.common.grib_helpers import construct_message
-from pproc.common.io import nan_to_missing
+from pproc.common.io import write_grib
 from pproc.common.parallel import (
     create_executor,
     parallel_data_retrieval,
@@ -109,9 +108,7 @@ def signi(
 
     clim_keys = {key: clim_template.get(key) for key in []}
     grib_keys.update(clim_keys)
-    message = construct_message(template, grib_keys)
-    message.set_array("values", nan_to_missing(message, pvalue))
-    target.write(message)
+    write_grib(target, template, pvalue, grib_keys)
 
 
 def signi_iteration(

--- a/src/pproc/thermo/helpers.py
+++ b/src/pproc/thermo/helpers.py
@@ -15,7 +15,7 @@ import thermofeel
 from meters import metered
 from typing import Optional
 
-from pproc import common
+from pproc.common.io import write_grib
 from pproc.config.targets import Target
 
 logger = logging.getLogger(__name__)
@@ -190,6 +190,5 @@ def write(
         # Handle wrapped metadata
         if hasattr(field_metadata, "extra"):
             updates.update(field_metadata.extra)
-        message = f.metadata()._handle.copy()
-        message.set(updates)
-        common.io.write_grib(target, message, f.values)
+        message = f.metadata()._handle
+        write_grib(target, message, f.values, updates)

--- a/src/pproc/wind.py
+++ b/src/pproc/wind.py
@@ -37,7 +37,7 @@ from pproc.config.types import WindConfig
 from pproc.config.targets import NullTarget
 
 
-def wind_template(step: int, **out_keys) -> dict:
+def wind_metadata(step: int, **out_keys) -> dict:
     grib_sets = {
         "bitsPerValue": 24,
         "step": step,
@@ -78,7 +78,7 @@ def wind_iteration(
                     if number > 0 and template.get("type") in ["cf", "fc"]
                     else template.get("type")
                 )
-                metadata = wind_template(
+                metadata = wind_metadata(
                     **dims,
                     number=number,
                     type=marstype,
@@ -89,7 +89,7 @@ def wind_iteration(
                     config.outputs.ws.target, template, ens[number], metadata
                 )
 
-        mean_keys = wind_template(
+        mean_keys = wind_metadata(
             **dims,
             **config.outputs.mean.metadata,
             **param.metadata,
@@ -98,7 +98,7 @@ def wind_iteration(
             config.outputs.mean.target, template, np.mean(ens, axis=0), mean_keys
         )
 
-        std_keys = wind_template(
+        std_keys = wind_metadata(
             **dims,
             **config.outputs.std.metadata,
             **param.metadata,

--- a/src/pproc/wind.py
+++ b/src/pproc/wind.py
@@ -37,10 +37,7 @@ from pproc.config.types import WindConfig
 from pproc.config.targets import NullTarget
 
 
-def wind_template(
-    template: eccodes.GRIBMessage, step: int, **out_keys
-) -> eccodes.GRIBMessage:
-    new_template = template.copy()
+def wind_template(step: int, **out_keys) -> dict:
     grib_sets = {
         "bitsPerValue": 24,
         "step": step,
@@ -53,8 +50,7 @@ def wind_template(
     else:
         grib_sets["timeRangeIndicator"] = 0
 
-    new_template.set(grib_sets)
-    return new_template
+    return grib_sets
 
 
 def wind_iteration(
@@ -82,34 +78,33 @@ def wind_iteration(
                     if number > 0 and template.get("type") in ["cf", "fc"]
                     else template.get("type")
                 )
-                template = wind_template(
-                    template,
+                metadata = wind_template(
                     **dims,
                     number=number,
                     type=marstype,
                     **config.outputs.ws.metadata,
                     **param.metadata,
                 )
-                common.io.write_grib(config.outputs.ws.target, template, ens[number])
+                common.io.write_grib(
+                    config.outputs.ws.target, template, ens[number], metadata
+                )
 
-        template_mean = wind_template(
-            template,
+        mean_keys = wind_template(
             **dims,
             **config.outputs.mean.metadata,
             **param.metadata,
         )
         common.io.write_grib(
-            config.outputs.mean.target, template_mean, np.mean(ens, axis=0)
+            config.outputs.mean.target, template, np.mean(ens, axis=0), mean_keys
         )
 
-        template_std = wind_template(
-            template,
+        std_keys = wind_template(
             **dims,
             **config.outputs.std.metadata,
             **param.metadata,
         )
         common.io.write_grib(
-            config.outputs.std.target, template_std, np.std(ens, axis=0)
+            config.outputs.std.target, template, np.std(ens, axis=0), std_keys
         )
 
     for name in config.outputs.names:


### PR DESCRIPTION
### Description
- Standardise setting creation of final message with data values across entrypoints to use `write_grib`
- Set `bitsPerValue` separately from other grib keys, and just before setting of data values
- Save `bitsPerValue` from original message in `GribMetadata` (as is done in earthkit-data) as default value in final message if not specified in config metadata 

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 