### PR TITLE
Add model to ecpoint output mars keys

### DIFF
--- a/src/pproc/common/param_requester.py
+++ b/src/pproc/common/param_requester.py
@@ -123,13 +123,17 @@ class ParamRequester:
             )
             metadata.append(pinput.base_request())
             data_list.append(data)
-            templates.append(new_templates)
+            templates.extend(new_templates)
 
         assert templates is not None, "No data fetched"
 
         new_metadata, data_list = self.param.preprocessing.apply(metadata, data_list)
         assert len(data_list) == 1, "More than one output of preprocessing"
-        templates = sum(templates[: len(data_list[0])], [])
+        templates = templates[: len(data_list[0])]
+        assert len(templates) == len(
+            data_list[0]
+        ), "Number of templates should match number of fields"
+
         metadata_set = {
             k: v for k, v in new_metadata[0].items() if v != metadata[0].get(k, None)
         }

--- a/src/pproc/config/types.py
+++ b/src/pproc/config/types.py
@@ -1049,6 +1049,7 @@ class ECPointConfig(QuantilesConfig):
 
     def _format_out(self, param: ParamConfig, req) -> dict:
         req = super()._format_out(param, req)
+        req["model"] = "ecPoint"
         if req["type"] == "pfc":
             return req
 

--- a/src/pproc/ecpoint.py
+++ b/src/pproc/ecpoint.py
@@ -68,10 +68,11 @@ def grid_bc_metadata(
     if edition not in (1, 2):
         raise ValueError(f"Unsupported GRIB edition {edition}")
 
-    grib_keys = out_keys.copy()
+    grib_keys = {}
     if edition == 2:
         grib_keys.update(
             {
+                "edition": 2,
                 "productDefinitionTemplateNumber": 73,
                 "type": "gbf",
                 "inputProcessIdentifier": template.get("generatingProcessIdentifier"),
@@ -82,6 +83,7 @@ def grid_bc_metadata(
                 "timeIncrement": 1,
             }
         )
+    grib_keys.update(out_keys)
     return template, grib_keys
 
 
@@ -92,15 +94,14 @@ def weather_types_metadata(
     if edition not in (1, 2):
         raise ValueError(f"Unsupported GRIB edition {edition}")
 
-    grib_keys = out_keys.copy()
+    grib_keys = {}
     if edition == 2:
         # `typeOfOriginalFieldValues` needs to be set separately as it is a helper key for
         # the packing, which doesn't exist any more after the packingType has been set
         template = template.copy()
-        template.set({"edition": 2, "typeOfOriginalFieldValues": 1}, check_values=False)
+        template.set({"edition": 2, "productDefinitionTemplateNumber": 73, "typeOfOriginalFieldValues": 1}, check_values=False)
         grib_keys.update(
             {
-                "productDefinitionTemplateNumber": 73,
                 "type": "gwt",
                 "packingType": "grid_ieee",
                 "inputProcessIdentifier": template.get("generatingProcessIdentifier"),
@@ -111,6 +112,7 @@ def weather_types_metadata(
                 "timeIncrement": 1,
             }
         )
+    grib_keys.update(out_keys)
     return template, grib_keys
 
 
@@ -121,10 +123,11 @@ def point_scale_metadata(
     if edition not in (1, 2):
         raise ValueError(f"Unsupported GRIB edition {edition}")
 
-    grib_keys = out_keys.copy()
+    grib_keys = {}
     if edition == 2:
         grib_keys.update(
             {
+                "edition": 2,
                 "productDefinitionTemplateNumber": 90,
                 "type": "pfc",
                 "inputProcessIdentifier": template.get("generatingProcessIdentifier"),
@@ -135,6 +138,7 @@ def point_scale_metadata(
                 "timeIncrement": 1,
             }
         )
+    grib_keys.update(out_keys)
     return quantiles_metadata(template, pert_number, total_number, grib_keys)
 
 

--- a/src/pproc/ecpoint.py
+++ b/src/pproc/ecpoint.py
@@ -102,13 +102,13 @@ def weather_types_metadata(
         template.set(
             {
                 "edition": 2,
-                "productDefinitionTemplateNumber": 73,
                 "typeOfOriginalFieldValues": 1,
             },
             check_values=False,
         )
         grib_keys.update(
             {
+                "productDefinitionTemplateNumber": 73,
                 "type": "gwt",
                 "packingType": "grid_ieee",
                 "inputProcessIdentifier": template.get("generatingProcessIdentifier"),

--- a/src/pproc/ecpoint.py
+++ b/src/pproc/ecpoint.py
@@ -99,7 +99,14 @@ def weather_types_metadata(
         # `typeOfOriginalFieldValues` needs to be set separately as it is a helper key for
         # the packing, which doesn't exist any more after the packingType has been set
         template = template.copy()
-        template.set({"edition": 2, "productDefinitionTemplateNumber": 73, "typeOfOriginalFieldValues": 1}, check_values=False)
+        template.set(
+            {
+                "edition": 2,
+                "productDefinitionTemplateNumber": 73,
+                "typeOfOriginalFieldValues": 1,
+            },
+            check_values=False,
+        )
         grib_keys.update(
             {
                 "type": "gwt",


### PR DESCRIPTION
### Description
- Add `model` into ecpoint output keys 
- Fix number of templates returned in `ParamRequester.retrieve_data`
- Allow default ecpoint edition 2 keys to be overrided from config

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 