### PR TITLE
Remove `std_anomaly_windows` from `LegacyStepAccumulation`

### DIFF
--- a/src/pproc/common/window.py
+++ b/src/pproc/common/window.py
@@ -96,10 +96,10 @@ def translate_window_config(
 def _iter_legacy_windows(
     windows: list,
     grib_keys: dict,
-    prefix: str = "",
 ) -> Iterator[Tuple[str, dict]]:
     for window_index, window_config in enumerate(windows):
         window_config = window_config.copy()
+        prefix = "STDANOM_" if window_config.get("std_anomaly", False) else ""
         for coord in window_config.pop("coords"):
             coord_config = window_config.copy()
             acc_grib_keys = grib_keys.copy()
@@ -113,6 +113,3 @@ def _iter_legacy_windows(
 
 def legacy_window_factory(config: dict, grib_keys: dict) -> Iterator[Tuple[str, dict]]:
     yield from _iter_legacy_windows(config["windows"], grib_keys)
-    yield from _iter_legacy_windows(
-        config.get("std_anomaly_windows", []), grib_keys, prefix="std_"
-    )

--- a/src/pproc/config/accumulation.py
+++ b/src/pproc/config/accumulation.py
@@ -333,7 +333,6 @@ class DateSeqAccumulation(BaseAccumulation):
 class LegacyStepAccumulation(BaseModel):
     type_: Literal["legacywindow"] = Field("legacywindow", alias="type")
     windows: list[LegacyWindowConfig] = []
-    std_anomaly_windows: Optional[list[LegacyWindowConfig]] = None
 
     def make_configs(self, metadata: dict) -> Iterator[Tuple[str, dict]]:
         return legacy_window_factory(
@@ -343,7 +342,7 @@ class LegacyStepAccumulation(BaseModel):
 
     def unique_coords(self):
         coords = set()
-        for window in self.windows + (self.std_anomaly_windows or []):
+        for window in self.windows:
             coords.update(window.unique_coords())
 
         coords = list(coords)
@@ -351,10 +350,7 @@ class LegacyStepAccumulation(BaseModel):
         return coords
 
     def out_mars(self, dim: str) -> list[dict]:
-        out_accum = [window.out_mars(dim) for window in self.windows]
-        if self.std_anomaly_windows is not None:
-            out_accum += [window.out_mars(dim) for window in self.std_anomaly_windows]
-        return out_accum
+        return [window.out_mars(dim) for window in self.windows]
 
     @classmethod
     def merge_windows(
@@ -382,21 +378,19 @@ class LegacyStepAccumulation(BaseModel):
             raise ValueError("Merge only possible with other LegacyStepAccumulation")
         current = self.model_copy(deep=True)
 
-        for wtype in ["windows", "std_anomaly_windows"]:
-            current_windows = getattr(current, wtype, None)
-            other_windows = getattr(other, wtype, None)
-            if current_windows is None:
-                if other_windows is not None:
-                    setattr(current, wtype, other_windows)
-                continue
-
+        current_windows = getattr(current, "windows", None)
+        other_windows = getattr(other, "windows", None)
+        if current_windows is None:
+            if other_windows is not None:
+                setattr(current, "windows", other_windows)
+        else:
             current_windows = self.merge_windows(current_windows, other_windows)
             # Recursively merge windows internally
             self_merge = self.merge_windows(current_windows, current_windows)
             while self_merge != current_windows:
                 current_windows = self_merge
                 self_merge = self.merge_windows(current_windows, current_windows)
-            setattr(current, wtype, current_windows)
+            setattr(current, "windows", current_windows)
         return current.model_validate(current)
 
 

--- a/src/pproc/config/accumulation.py
+++ b/src/pproc/config/accumulation.py
@@ -131,7 +131,7 @@ class LegacyWindowConfig(BaseModel):
 
 
 def _to_date(
-    arg: Union[str, Tuple[int, int, int], datetime.date, datetime.datetime]
+    arg: Union[str, Tuple[int, int, int], datetime.date, datetime.datetime],
 ) -> datetime.date:
     if isinstance(arg, datetime.datetime):
         return arg.date()
@@ -351,8 +351,8 @@ class LegacyStepAccumulation(BaseModel):
         return coords
 
     def out_mars(self, dim: str) -> list[dict]:
-        out_accum = [window.out_mars(dim) for window in self.windows] 
-        if std_anomaly_windows is not None:
+        out_accum = [window.out_mars(dim) for window in self.windows]
+        if self.std_anomaly_windows is not None:
             out_accum += [window.out_mars(dim) for window in self.std_anomaly_windows]
         return out_accum
 

--- a/src/pproc/config/accumulation.py
+++ b/src/pproc/config/accumulation.py
@@ -351,7 +351,10 @@ class LegacyStepAccumulation(BaseModel):
         return coords
 
     def out_mars(self, dim: str) -> list[dict]:
-        return [window.out_mars(dim) for window in self.windows]
+        out_accum = [window.out_mars(dim) for window in self.windows] 
+        if std_anomaly_windows is not None:
+            out_accum += [window.out_mars(dim) for window in self.std_anomaly_windows]
+        return out_accum
 
     @classmethod
     def merge_windows(

--- a/src/pproc/config/accumulation.py
+++ b/src/pproc/config/accumulation.py
@@ -378,19 +378,13 @@ class LegacyStepAccumulation(BaseModel):
             raise ValueError("Merge only possible with other LegacyStepAccumulation")
         current = self.model_copy(deep=True)
 
-        current_windows = getattr(current, "windows", None)
-        other_windows = getattr(other, "windows", None)
-        if current_windows is None:
-            if other_windows is not None:
-                setattr(current, "windows", other_windows)
-        else:
-            current_windows = self.merge_windows(current_windows, other_windows)
-            # Recursively merge windows internally
+        current_windows = self.merge_windows(current.windows, other.windows)
+        # Recursively merge windows internally
+        self_merge = self.merge_windows(current_windows, current_windows)
+        while self_merge != current_windows:
+            current_windows = self_merge
             self_merge = self.merge_windows(current_windows, current_windows)
-            while self_merge != current_windows:
-                current_windows = self_merge
-                self_merge = self.merge_windows(current_windows, current_windows)
-            setattr(current, "windows", current_windows)
+        current.windows = current_windows
         return current.model_validate(current)
 
 

--- a/src/pproc/config/base.py
+++ b/src/pproc/config/base.py
@@ -331,14 +331,9 @@ class BaseConfig(ConfigModel):
             step_accum["coords"] = [steps]
 
             if step_accum.get("type") == "legacywindow":
-                window_list = (
-                    "std_anomaly_windows"
-                    if step_accum.get("std_anomaly")
-                    else "windows"
-                )
                 accums["step"] = {
                     "type": step_accum.pop("type"),
-                    window_list: [step_accum],
+                    "windows": [step_accum],
                 }
         return accums
 

--- a/src/pproc/prob/accumulation_manager.py
+++ b/src/pproc/prob/accumulation_manager.py
@@ -77,7 +77,7 @@ class ThresholdAccumulationManager(AccumulationManager):
         anomaly = data - clim_mean
         std_anomaly = anomaly / clim_std
         for identifier, accum in list(self.accumulations.items()):
-            if identifier.split("_")[0] == "std":
+            if "STDANOM" in identifier.split("_"):
                 processed = accum.feed(keys, std_anomaly)
             else:
                 processed = accum.feed(keys, anomaly)

--- a/tests/common/test_window.py
+++ b/tests/common/test_window.py
@@ -794,10 +794,9 @@ def test_grib_header(steps, operation, extra_keys, grib_key_values):
                         ],
                         "metadata": {"bitsPerValue": 24},
                     },
-                ],
-                "std_anomaly_windows": [
                     {
                         "operation": "maximum",
+                        "std_anomaly": True,
                         "thresholds": [
                             {"comparison": ">", "value": 1},
                         ],
@@ -809,6 +808,7 @@ def test_grib_header(steps, operation, extra_keys, grib_key_values):
                     },
                     {
                         "operation": "minimum",
+                        "std_anomaly": True,
                         "thresholds": [
                             {"comparison": "<", "value": -1.5},
                         ],
@@ -872,8 +872,9 @@ def test_grib_header(steps, operation, extra_keys, grib_key_values):
                     ]
                 },
                 **{
-                    f"std_{s}_{index}": {
+                    f"STDANOM_{s}_{index + 3}": {
                         "operation": op,
+                        "std_anomaly": True,
                         "coords": [s],
                         "sequential": True,
                         "thresholds": [{"comparison": cmp, "value": val}],

--- a/tests/config/test_accum.py
+++ b/tests/config/test_accum.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pproc.config.accumulation import LegacyWindowConfig
+from pproc.config.accumulation import LegacyWindowConfig, LegacyStepAccumulation
 
 
 @pytest.mark.parametrize(
@@ -67,3 +67,107 @@ def test_legacy_merge(config1, config2, merged, expected):
     assert accum1.merge(accum2) == merged
     if merged:
         assert accum1 == LegacyWindowConfig(**expected)
+
+
+@pytest.mark.parametrize(
+    "config, expected",
+    [
+        [
+            {
+                "windows": [
+                    {
+                        "operation": "minimum",
+                        "coords": [[0]],
+                        "thresholds": [{"out_paramid": 1}],
+                    }
+                ]
+            },
+            [{"param": [1], "step": [0]}],
+        ],
+        [
+            {
+                "windows": [
+                    {
+                        "operation": "minimum",
+                        "coords": [[0, 6]],
+                        "thresholds": [{"out_paramid": 1}],
+                    }
+                ]
+            },
+            [{"param": [1], "step": ["0-6"]}],
+        ],
+        [
+            {
+                "windows": [
+                    {
+                        "operation": "minimum",
+                        "coords": [[0]],
+                        "thresholds": [{"out_paramid": 1}],
+                    },
+                    {
+                        "operation": "minimum",
+                        "coords": [[6]],
+                        "thresholds": [{"out_paramid": 1}],
+                    },
+                ]
+            },
+            [{"param": [1], "step": [0]}, {"param": [1], "step": [6]}],
+        ],
+        [
+            {
+                "windows": [
+                    {
+                        "operation": "minimum",
+                        "coords": [[0], [6]],
+                        "thresholds": [{"out_paramid": 1}],
+                    },
+                ]
+            },
+            [{"param": [1], "step": [0, 6]}],
+        ],
+        [
+            {
+                "windows": [
+                    {
+                        "operation": "minimum",
+                        "coords": [[0]],
+                        "thresholds": [{"out_paramid": 1}, {"out_paramid": 2}],
+                    }
+                ]
+            },
+            [{"param": [1, 2], "step": [0]}],
+        ],
+        [
+            {
+                "windows": [
+                    {
+                        "operation": "minimum",
+                        "coords": [[0]],
+                        "thresholds": [{"out_paramid": 1}],
+                    }
+                ],
+                "std_anomaly_windows": [
+                    {
+                        "operation": "minimum",
+                        "coords": [[0]],
+                        "thresholds": [{"out_paramid": 2}],
+                    },
+                    {
+                        "operation": "minimum",
+                        "coords": [[6]],
+                        "thresholds": [{"out_paramid": 2}],
+                    },
+                ],
+            },
+            [
+                {"param": [1], "step": [0]},
+                {"param": [2], "step": [0]},
+                {"param": [2], "step": [6]},
+            ],
+        ],
+    ],
+    ids=["simple", "range", "windows", "multi-step", "multi-threshold", "anomaly"],
+)
+def test_legacy_out_mars(config, expected):
+    config = LegacyStepAccumulation(**config)
+    assert config.out_mars(dim="step") == expected

--- a/tests/config/test_accum.py
+++ b/tests/config/test_accum.py
@@ -144,11 +144,10 @@ def test_legacy_merge(config1, config2, merged, expected):
                         "operation": "minimum",
                         "coords": [[0]],
                         "thresholds": [{"out_paramid": 1}],
-                    }
-                ],
-                "std_anomaly_windows": [
+                    },
                     {
                         "operation": "minimum",
+                        "std_anomaly": True,
                         "coords": [[0]],
                         "thresholds": [{"out_paramid": 2}],
                     },

--- a/tests/prob/test_prob_accumulation_manager.py
+++ b/tests/prob/test_prob_accumulation_manager.py
@@ -232,10 +232,9 @@ def test_create_threshold(config, expected, exp_coords):
                             {"from": 336, "to": 360, "by": 12},
                         ],
                     },
-                ],
-                "std_anomaly_windows": [
                     {
                         "operation": "maximum",
+                        "std_anomaly": True,
                         "thresholds": [
                             {"comparison": ">", "value": 1},
                         ],
@@ -243,6 +242,7 @@ def test_create_threshold(config, expected, exp_coords):
                     },
                     {
                         "operation": "minimum",
+                        "std_anomaly": True,
                         "thresholds": [
                             {"comparison": "<", "value": -1.5},
                         ],
@@ -275,7 +275,7 @@ def test_create_threshold(config, expected, exp_coords):
                     for a, b in [(120, 240), (336, 360)]
                 },
                 **{
-                    f"step_std_{s}_{index}": (
+                    f"step_STDANOM_{s}_{index + 3}": (
                         SimpleAccumulation,
                         [{"comparison": cmp, "value": val}],
                     )

--- a/tests/schema/test_input_schema.py
+++ b/tests/schema/test_input_schema.py
@@ -472,20 +472,25 @@ def test_redundant_inputs(inputs, template, num_outputs):
     )
     assert len(generated) == num_outputs
 
-@pytest.mark.parametrize("number, updates", [
-    [0, {"type": "cf"}], 
-    [[0, 1], [{"type": "cf"}, {"type": "pf", "number": [1]}]], 
-    [1, {"type": "pf", "number": [1]}],
-], ids=["cf", "cf-and-pf", "pf"])
+
+@pytest.mark.parametrize(
+    "number, updates",
+    [
+        [0, {"type": "cf"}],
+        [[0, 1], [{"type": "cf"}, {"type": "pf", "number": [1]}]],
+        [1, {"type": "pf", "number": [1]}],
+    ],
+    ids=["cf", "cf-and-pf", "pf"],
+)
 def test_fcstat_inputs(number, updates):
     input_schema = InputSchema(schema("inputs"))
     step_schema = StepSchema(schema("windows"))
     output = {
-        "stream": "eefo", 
+        "stream": "eefo",
         "type": "fcmean",
-        "number": number, 
-        "param": "167", 
-        "step": "0-168", 
+        "number": number,
+        "param": "167",
+        "step": "0-168",
         "time": "0000",
     }
     inputs = input_schema.inputs(output, step_schema)

--- a/tests/templates/t850.yaml
+++ b/tests/templates/t850.yaml
@@ -53,9 +53,9 @@ parameters:
             value: 2
           metadata:
             bitsPerValue: 24
-        std_anomaly_windows:
         - coords: [[0], [12]]
           operation: maximum
+          std_anomaly: true 
           thresholds:
           - out_paramid: 133093
             comparison: '>'
@@ -75,6 +75,7 @@ parameters:
             scaledValueOfUpperLimit: MISSING
         - coords: [[0], [12]]
           operation: minimum
+          std_anomaly: true 
           thresholds:
           - out_paramid: 133096
             comparison: <


### PR DESCRIPTION
### Description
Remove `std_anomaly_windows` from `LegacyStepAccumulation` and use `std_anomaly` boolean flag instead to differentiate.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 