### PR TITLE
Allow named sequences in `ClimDateDeriver`

### DIFF
--- a/src/pproc/schema/deriver.py
+++ b/src/pproc/schema/deriver.py
@@ -179,12 +179,16 @@ class ClimDateDeriver(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     option: str
+    sequence: Optional[str] = None
 
     def derive(self, fc_request: dict, scheme: str) -> str | list[str]:
         date = datetime.datetime.strptime(str(fc_request["date"]), "%Y%m%d")
-        clim_seq = Sequence.from_resource(scheme)
-        kwargs = self.model_dump(exclude={"option"})
-        clim_date = getattr(clim_seq, self.option)(date.date(), **kwargs)
+        if self.sequence is not None:
+            seq = Sequence.from_dict({"type": self.sequence})
+        else:
+            seq = Sequence.from_resource(scheme)
+        kwargs = self.model_dump(exclude={"option", "sequence"})
+        clim_date = getattr(seq, self.option)(date.date(), **kwargs)
         if isinstance(clim_date, datetime.date):
             return datetime.datetime.strftime(clim_date, "%Y%m%d")
         return [datetime.datetime.strftime(x, "%Y%m%d") for x in clim_date]

--- a/src/pproc/schema/deriver.py
+++ b/src/pproc/schema/deriver.py
@@ -179,12 +179,12 @@ class ClimDateDeriver(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     option: str
-    sequence: Optional[str] = None
+    sequence: Optional[dict] = None
 
     def derive(self, fc_request: dict, scheme: str) -> str | list[str]:
         date = datetime.datetime.strptime(str(fc_request["date"]), "%Y%m%d")
         if self.sequence is not None:
-            seq = Sequence.from_dict({"type": self.sequence})
+            seq = Sequence.from_dict(self.sequence)
         else:
             seq = Sequence.from_resource(scheme)
         kwargs = self.model_dump(exclude={"option", "sequence"})

--- a/tests/schema/schema.yaml
+++ b/tests/schema/schema.yaml
@@ -3363,7 +3363,8 @@ inputs:
                 type: cd
               derive_date: 
                 - option: next
-                  sequence: daily
+                  sequence: 
+                    type: daily
                 - option: previous
                   strict: false
               derive_step: 

--- a/tests/schema/schema.yaml
+++ b/tests/schema/schema.yaml
@@ -3342,20 +3342,32 @@ inputs:
                     type: monthly
                     by: 12
     efi/efic/sot:
-      climatology:
-        required: true
-        inputs:
-          request:
-            type: cd
-          derive_date: 
-            option: nearest
-          derive_step: 
-            type: range
       filter:stream:
         "eefo/weef": 
           filter:param:
-            132044/132049/132059/132144/132045/132165/132167/132201/132202/132216/132228: {}
-        "*":
+            132044/132049/132059/132144/132045/132165/132167/132201/132202/132216/132228: 
+              climatology:
+                required: true
+                inputs:
+                  request:
+                    type: cd
+                  derive_date: 
+                    option: nearest
+                  derive_step: 
+                    type: range
+        "enfo/waef":
+          climatology:
+            required: true
+            inputs:
+              request:
+                type: cd
+              derive_date: 
+                - option: next
+                  sequence: daily
+                - option: previous
+                  strict: false
+              derive_step: 
+                type: range
           filter:param:
             "132044/132049/132059/132045/132165/132167/132201/132202/132216": 
               forecast:

--- a/tests/schema/test_deriver.py
+++ b/tests/schema/test_deriver.py
@@ -1,6 +1,102 @@
 import pytest
 
-from pproc.schema.deriver import ClimDateDeriver
+from pproc.schema.deriver import ClimStepDeriver, ClimDateDeriver
+
+
+@pytest.mark.parametrize(
+    "step_type, time, step, clim_steps, expected",
+    [
+        [
+            "instantaneous",
+            "0000",
+            [12, 24, 360],
+            list(range(0, 361, 12)),
+            [12, 24, 360],
+        ],
+        [
+            "instantaneous",
+            "0600",
+            [12, 24, 360],
+            list(range(0, 361, 12)),
+            [12, 24, 360],
+        ],
+        [
+            "instantaneous",
+            "1200",
+            [12, 24, 360],
+            list(range(0, 361, 12)),
+            [24, 36, 348],
+        ],
+        [
+            "instantaneous",
+            "1800",
+            [12, 24, 360],
+            list(range(0, 361, 12)),
+            [24, 36, 348],
+        ],
+        [
+            "range",
+            "0000",
+            list(range(0, 25, 12)),
+            ["0-24", "12-36", "24-28", "0-240"],
+            "0-24",
+        ],
+        [
+            "range",
+            "0000",
+            list(range(0, 241, 12)),
+            ["0-24", "12-36", "24-28", "0-240"],
+            "0-240",
+        ],
+        [
+            "range",
+            "0600",
+            list(range(0, 25, 12)),
+            ["0-24", "12-36", "24-28", "0-240"],
+            "0-24",
+        ],
+        [
+            "range",
+            "0600",
+            list(range(0, 241, 12)),
+            ["0-24", "12-36", "24-28", "0-240"],
+            "0-240",
+        ],
+        [
+            "range",
+            "1200",
+            list(range(0, 25, 12)),
+            ["0-24", "12-36", "24-28", "0-240"],
+            "12-36",
+        ],
+        [
+            "range",
+            "1200",
+            list(range(0, 241, 12)),
+            ["0-24", "12-36", "24-28", "0-240"],
+            "0-240",
+        ],
+        [
+            "range",
+            "1800",
+            list(range(0, 25, 12)),
+            ["0-24", "12-36", "24-28", "0-240"],
+            "12-36",
+        ],
+        [
+            "range",
+            "1800",
+            list(range(0, 241, 12)),
+            ["0-24", "12-36", "24-28", "0-240"],
+            "0-240",
+        ],
+        ["range", "0000", ["0-168"], ["0-168", "24-192", "48-216"], "0-168"],
+        ["range", "0000", ["24-192"], ["0-168", "24-192", "48-216"], "24-192"],
+    ],
+)
+def test_clim_step_deriver(step_type, time, step, clim_steps, expected):
+    deriver = ClimStepDeriver(type=step_type)
+    assert deriver.derive({"time": time, "step": step}, clim_steps) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/schema/test_deriver.py
+++ b/tests/schema/test_deriver.py
@@ -1,0 +1,21 @@
+import pytest
+
+from pproc.schema.deriver import ClimDateDeriver
+
+
+@pytest.mark.parametrize(
+    "config, date, expected",
+    [
+        [{"option": "next", "sequence": "daily"}, "20250930", ["20251001"]],
+        [{"option": "previous", "strict": False}, "20250930", ["20250929"]],
+        [{"option": "nearest"}, "20250930", ["20250929"]],
+        [
+            {"option": "bracket", "num": 1, "strict": False},
+            "20250930",
+            ["20250929", "20251001"],
+        ],
+    ],
+)
+def test_clim_date_deriver(config, date, expected):
+    deriver = ClimDateDeriver(**config)
+    deriver.derive({"date": date}, "ecmwf-2days") == [expected]

--- a/tests/schema/test_deriver.py
+++ b/tests/schema/test_deriver.py
@@ -6,9 +6,10 @@ from pproc.schema.deriver import ClimDateDeriver
 @pytest.mark.parametrize(
     "config, date, expected",
     [
-        [{"option": "next", "sequence": "daily"}, "20250930", ["20251001"]],
-        [{"option": "previous", "strict": False}, "20250930", ["20250929"]],
-        [{"option": "nearest"}, "20250930", ["20250929"]],
+        [{"option": "next", "sequence": "daily"}, "20250930", "20251001"],
+        [{"option": "previous", "strict": False}, "20250930", "20250929"],
+        [{"option": "previous"}, "20250929", "20250927"],
+        [{"option": "nearest"}, "20250930", "20250929"],
         [
             {"option": "bracket", "num": 1, "strict": False},
             "20250930",
@@ -18,4 +19,4 @@ from pproc.schema.deriver import ClimDateDeriver
 )
 def test_clim_date_deriver(config, date, expected):
     deriver = ClimDateDeriver(**config)
-    deriver.derive({"date": date}, "ecmwf-2days") == [expected]
+    assert deriver.derive({"date": date}, "ecmwf-2days") == expected

--- a/tests/schema/test_deriver.py
+++ b/tests/schema/test_deriver.py
@@ -102,7 +102,7 @@ def test_clim_step_deriver(step_type, time, step, clim_steps, expected):
 @pytest.mark.parametrize(
     "config, date, expected",
     [
-        [{"option": "next", "sequence": "daily"}, "20250930", "20251001"],
+        [{"option": "next", "sequence": {"type": "daily"}}, "20250930", "20251001"],
         [{"option": "previous", "strict": False}, "20250930", "20250929"],
         [{"option": "previous"}, "20250929", "20250927"],
         [{"option": "nearest"}, "20250930", "20250929"],


### PR DESCRIPTION
### Description
Modify `ClimDateDeriver` to handle named sequences, e.g. `daily`, as well as sequences from resource

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 