### PR TITLE
Save filelocks used in `FileSetTarget`

### DIFF
--- a/src/pproc/config/targets.py
+++ b/src/pproc/config/targets.py
@@ -156,7 +156,7 @@ class FileSetTarget(Target):
 
     def write(self, message):
         path = self.path.format_map(message)
-        with self._file_locks.get(path, FileLock(path + ".lock")):
+        with self._file_locks.setdefault(path, FileLock(path + ".lock")):
             if self._overwrite_existing:
                 remove_duplicate(path, message)
             with open(path, self.mode(path)) as file:


### PR DESCRIPTION
### Description
Small bug fix relating to saving of filelocks used in `FileSetTarget`.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 