### PR TITLE
Bugfix `DeaccumulationWrapper` when initialising with 0

### DIFF
--- a/src/pproc/common/accumulation.py
+++ b/src/pproc/common/accumulation.py
@@ -614,10 +614,13 @@ class DeaccumulationWrapper(Accumulation):
         if len(accumulation.coords) < 2:
             raise ValueError("Deaccumulation can not be performed on single coord")
         self.coords = copy.deepcopy(accumulation.coords)
-        self.zero_initial = int(accumulation.name.split("-")[0]) not in self.coords
-        # Remove first coord from accumulation
-        accumulation.coords = list(accumulation.coords)
-        accumulation.coords.pop(0)
+        self.zero_initial = (
+            int(accumulation.name.split("-")[0].split("_")[-1]) not in self.coords
+        )
+        # Remove first coord from accumulation if not initialising with 0
+        if not self.zero_initial:
+            accumulation.coords = list(accumulation.coords)
+            accumulation.coords.pop(0)
         self.acc = accumulation
         self.sequential = accumulation.sequential
         self.reset(initial=True)


### PR DESCRIPTION
### Description
Include all coords when initialising values with 0

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 