### PR TITLE
Feature/cpf from zero

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ requires-python = ">=3.8"
 dependencies = [
     "code-meters >= 0.0.3",
     "earthkit-data >= 0.13.2",
-    "earthkit-meteo >= 0.1.1",
+    "earthkit-meteo >= 0.5.0",
     "earthkit-time >= 0.1.3",
     "eccodes >= 1.6.1",
     "filelock >= 3.12.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ git+ssh://git@git.ecmwf.int/mars/pyfdb.git@develop
 psutil
 filelock>=3.12.0
 earthkit-data
-earthkit-meteo>=0.1.0
+earthkit-meteo>=0.5.0
 earthkit-time>=0.1.3
 thermofeel
 codetiming

--- a/src/pproc/config/types.py
+++ b/src/pproc/config/types.py
@@ -606,6 +606,7 @@ class ExtremeParamConfig(ClimParamConfig):
     sot: list[int] = []
     cpf_eps: Optional[float] = None
     cpf_symmetric: bool = False
+    cpf_from_zero: bool = True
     compute_indices: list[str] = ["efi", "sot"]
     allow_grib1_to_grib2: bool = False
     _merge_exclude: tuple[str] = (

--- a/src/pproc/extremes/indices.py
+++ b/src/pproc/extremes/indices.py
@@ -95,6 +95,7 @@ class CPF(Index):
             else None
         )
         self.symmetric = options.get("cpf_symmetric", False)
+        self.from_zero = options.get("cpf_from_zero", True)
 
     def compute(
         self,
@@ -112,6 +113,7 @@ class CPF(Index):
             sort_ens=True,
             epsilon=self.eps,
             symmetric=self.symmetric,
+            from_zero=self.from_zero,
         )
         cpf_keys = cpf_metadata(out_template, metadata)
         common.io.write_grib(target, out_template, cpf, cpf_keys)


### PR DESCRIPTION
### Description

Adds a 'cpf_from_zero' (default True) option to pproc-extreme for CPF. Requires earthkit-meteo >= 0.5.0

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 