### PR TITLE
Set `target`/`source` in input/output mars requests

### DIFF
--- a/src/pproc/common/mars.py
+++ b/src/pproc/common/mars.py
@@ -31,7 +31,10 @@ def _mkftemp(dir=None, mode=0o600, num_attempts=1000):
                 continue
             raise
         return path
-    raise OSError(errno.EEXIST, f"_mkftemp: No usable temporary name found after {num_attempts} attempts")
+    raise OSError(
+        errno.EEXIST,
+        f"_mkftemp: No usable temporary name found after {num_attempts} attempts",
+    )
 
 
 class FIFO:
@@ -122,7 +125,7 @@ class MARSReader:
             if self.fifo.wait(1e-2):
                 # We have data (or EOF)
                 break
-        buf = b''
+        buf = b""
         # Don't block again if there is nothing to read
         if self.fifo.ready():
             while len(buf) < size:
@@ -162,6 +165,8 @@ def _val_to_mars(val):
         val = f"{first}/to/{last}"
         if step != 1:
             val += f"/by/{step}"
+    elif isinstance(val, float) and val.is_integer():
+        val = str(int(val))
     else:
         raise TypeError(f"Cannot convert {type(val)} to MARS request")
     return val.encode("utf-8")
@@ -174,15 +179,18 @@ def to_mars(verb: bytes, req: dict) -> bytes:
             key = key.encode("utf-8")
             val = _val_to_mars(val)
             yield key + b"=" + val
+
     return b",".join(_gen_req())
 
 
-def mars_retrieve(req: dict, mars_cmd: Union[str, List[str]] = "mars", tmpdir=None) -> MARSReader:
+def mars_retrieve(
+    req: dict, mars_cmd: Union[str, List[str]] = "mars", tmpdir=None
+) -> MARSReader:
     req = copy.deepcopy(req)
     with ExitStack() as stack:
         req_file = stack.enter_context(NamedTemporaryFile(dir=tmpdir))
         fifo = stack.enter_context(FIFO(dir=tmpdir))
-        req['target'] = '"' + fifo.path + '"'
+        req["target"] = '"' + fifo.path + '"'
         req_s = to_mars(b"retrieve", req)
         req_file.write(req_s + b"\n")
         req_file.flush()

--- a/src/pproc/config/param.py
+++ b/src/pproc/config/param.py
@@ -155,7 +155,6 @@ class ParamConfig(BaseModel):
                         if pinput.type in ["file", "fileset"]
                         else pinput.type
                     )
-                    print("SOURCE", req["source"])
                     accum_updates = (
                         getattr(self, input).accumulations
                         if hasattr(self, input)

--- a/src/pproc/config/param.py
+++ b/src/pproc/config/param.py
@@ -103,37 +103,24 @@ class ParamConfig(BaseModel):
         )
 
         if self.vod2uv:
-            return [
-                Input(
-                    source={
-                        "type": cfg_source.get("type", base_config.type),
-                        "path": cfg_source.get("path", base_config.path),
-                    },
-                    request=reqs,
-                )
-            ]
-
-        reqs = list(expand(reqs, "param"))
-        df = pd.DataFrame(reqs).convert_dtypes()
-        if "param" in df:
-            return [
-                Input(
-                    source={
-                        "type": cfg_source.get("type", base_config.type),
-                        "path": cfg_source.get("path", base_config.path),
-                    },
-                    request=[row.dropna().to_dict() for _, row in items.iterrows()],
-                )
-                for _, items in df.groupby("param", sort=False)
-            ]
+            requests = [reqs]
+        else:
+            requests = [list(expand(reqs, "param"))]
+            df = pd.DataFrame(requests[0]).convert_dtypes()
+            if "param" in df:
+                requests = [
+                    [row.dropna().to_dict() for _, row in items.iterrows()]
+                    for _, items in df.groupby("param", sort=False)
+                ]
         return [
             Input(
                 source={
                     "type": cfg_source.get("type", base_config.type),
                     "path": cfg_source.get("path", base_config.path),
                 },
-                request=reqs,
+                request=param_requests,
             )
+            for param_requests in requests
         ]
 
     def in_keys(

--- a/src/pproc/config/param.py
+++ b/src/pproc/config/param.py
@@ -114,7 +114,7 @@ class ParamConfig(BaseModel):
             ]
 
         reqs = list(expand(reqs, "param"))
-        df = pd.DataFrame(reqs)
+        df = pd.DataFrame(reqs).convert_dtypes()
         if "param" in df:
             return [
                 Input(

--- a/src/pproc/config/param.py
+++ b/src/pproc/config/param.py
@@ -151,8 +151,11 @@ class ParamConfig(BaseModel):
                 )
                 for req in reqs:
                     req["source"] = (
-                        pinput.path if pinput.path is not None else pinput.type
+                        pinput.path
+                        if pinput.type in ["file", "fileset"]
+                        else pinput.type
                     )
+                    print("SOURCE", req["source"])
                     accum_updates = (
                         getattr(self, input).accumulations
                         if hasattr(self, input)

--- a/src/pproc/config/types.py
+++ b/src/pproc/config/types.py
@@ -976,9 +976,10 @@ class ECPointParamConfig(ParamConfig):
         for param in self.dependencies.values():
             requests.extend(param.in_keys(inputs, filters))
         unique = pd.DataFrame(expand(requests))
+        unique.drop(columns=["interpolate"], inplace=True, errors="ignore")
         unique.drop_duplicates(inplace=True)
         for _, group in unique.groupby("param", sort=False):
-            yield from squeeze(group.to_dict("records"), ["step"])
+            yield from squeeze(group.to_dict("records"), ["step", "number"])
 
     def _merge_dependencies(self, other: Self) -> dict[str, ParamConfig]:
         new_deps = {}

--- a/src/pproc/config/types.py
+++ b/src/pproc/config/types.py
@@ -22,6 +22,7 @@ from pydantic import (
 )
 import numpy as np
 import datetime
+import pandas as pd
 
 from conflator import CLIArg, ConfigModel
 from earthkit.time import DailySequence
@@ -30,7 +31,15 @@ from pproc.clustereps.season import MONTH_DAYS, Season
 from pproc.config.base import BaseConfig, Parallelisation
 from pproc.config import io
 from pproc.config.param import ParamConfig, partial_equality
-from pproc.config.utils import _set, _get, extract_mars, update_request, deep_update
+from pproc.config.utils import (
+    _set,
+    _get,
+    extract_mars,
+    update_request,
+    deep_update,
+    expand,
+    squeeze,
+)
 from pproc.config.preprocessing import Expression
 from pproc.common.stepseq import steprange_to_fcmonth
 from pproc.extremes.indices import Index, SUPPORTED_INDICES, create_indices
@@ -961,10 +970,15 @@ class ECPointParamConfig(ParamConfig):
     def in_keys(
         self, inputs: io.InputsCollection, filters: Optional[list[str]] = None
     ) -> Iterator[dict]:
-        yield from super().in_keys(inputs, filters)
+        requests = []
+        requests.extend(super().in_keys(inputs, filters))
 
         for param in self.dependencies.values():
-            yield from param.in_keys(inputs, filters)
+            requests.extend(param.in_keys(inputs, filters))
+        unique = pd.DataFrame(expand(requests))
+        unique.drop_duplicates(inplace=True)
+        for _, group in unique.groupby("param", sort=False):
+            yield from squeeze(group.to_dict("records"), ["step"])
 
     def _merge_dependencies(self, other: Self) -> dict[str, ParamConfig]:
         new_deps = {}

--- a/src/pproc/config/types.py
+++ b/src/pproc/config/types.py
@@ -267,7 +267,9 @@ class ClimParamConfig(ParamConfig):
                 )
                 for req in reqs:
                     req["source"] = (
-                        pinput.path if pinput.path is not None else pinput.type
+                        pinput.path
+                        if pinput.type in ["file", "fileset"]
+                        else pinput.type
                     )
                     if isinstance(req.get("step", []), dict):
                         req["step"] = list(set(req["step"].values()))
@@ -751,7 +753,9 @@ class ThermoParamConfig(ParamConfig):
                 )
                 for req in reqs:
                     req["source"] = (
-                        pinput.path if pinput.path is not None else pinput.type
+                        pinput.path
+                        if pinput.type in ["file", "fileset"]
+                        else pinput.type
                     )
                     req.update(
                         {
@@ -1447,7 +1451,9 @@ class ClusterFullConfig(
                 pinput.request if isinstance(pinput.request, list) else [pinput.request]
             )
             for req in reqs:
-                req["source"] = pinput.path if pinput.path is not None else pinput.type
+                req["source"] = (
+                    pinput.path if pinput.type in ["file", "fileset"] else pinput.type
+                )
                 req.update(acc_keys[input])
                 req.pop("interpolate", None)
                 if str(req) not in seen:

--- a/src/pproc/config/types.py
+++ b/src/pproc/config/types.py
@@ -975,7 +975,7 @@ class ECPointParamConfig(ParamConfig):
 
         for param in self.dependencies.values():
             requests.extend(param.in_keys(inputs, filters))
-        unique = pd.DataFrame(expand(requests))
+        unique = pd.DataFrame(expand(requests)).convert_dtypes()
         unique.drop(columns=["interpolate"], inplace=True, errors="ignore")
         unique.drop_duplicates(inplace=True)
         for _, group in unique.groupby("param", sort=False):

--- a/src/pproc/config/utils.py
+++ b/src/pproc/config/utils.py
@@ -146,6 +146,8 @@ def squeeze(reqs: list[dict], dims: list[str]) -> Iterator[dict]:
         cond_reqs = df.loc[condition].to_dict("records")
         for dim in dims:
             val = cond_reqs[0].get(dim, np.nan)
+            if val is None:
+                continue
             if isinstance(val, str) or not np.isnan(val):
                 req[dim] = sorted(list({x[dim] for x in cond_reqs}))
         yield req

--- a/src/pproc/config_generation.py
+++ b/src/pproc/config_generation.py
@@ -64,11 +64,12 @@ def from_inputs(args):
 def _to_mars(requests: list[dict]) -> str:
     ret = b""
     for req in requests:
-        if "source" in req:
-            assert "target" not in req
-            req["target"] = req.pop("source").replace("{", "[").replace("}", "]")
-        elif "target" in req:
-            req["source"] = req.pop("target").replace("{", "[").replace("}", "]")
+        source = req.pop("source")
+        target = req.pop("target")
+        if source not in ["fdb", "mars"]:
+            req["target"] = source.replace("{", "[").replace("}", "]")
+        elif target not in ["fdb", "mars"]:
+            req["source"] = target.replace("{", "[").replace("}", "]")
         ret += mars.to_mars(b"retrieve", req)
         ret += b"\n"
     return ret.decode("utf-8")

--- a/src/pproc/config_generation.py
+++ b/src/pproc/config_generation.py
@@ -64,8 +64,11 @@ def from_inputs(args):
 def _to_mars(requests: list[dict]) -> str:
     ret = b""
     for req in requests:
-        req.pop("source", None)
-        req.pop("target", None)
+        if "source" in req:
+            assert "target" not in req
+            req["target"] = req.pop("source").replace("{", "[").replace("}", "]")
+        elif "target" in req:
+            req["source"] = req.pop("target").replace("{", "[").replace("}", "]")
         ret += mars.to_mars(b"retrieve", req)
         ret += b"\n"
     return ret.decode("utf-8")

--- a/src/pproc/config_generation.py
+++ b/src/pproc/config_generation.py
@@ -67,9 +67,13 @@ def _to_mars(requests: list[dict]) -> str:
         source = req.pop("source")
         target = req.pop("target")
         if source not in ["fdb", "mars"]:
-            req["target"] = source.replace("{", "[").replace("}", "]")
+            req["target"] = "'{path}'".format(
+                path=source.replace("{", "[").replace("}", "]")
+            )
         elif target not in ["fdb", "mars"]:
-            req["source"] = target.replace("{", "[").replace("}", "]")
+            req["source"] = "'{path}'".format(
+                path=target.replace("{", "[").replace("}", "]")
+            )
         ret += mars.to_mars(b"retrieve", req)
         ret += b"\n"
     return ret.decode("utf-8")

--- a/src/pproc/config_generation.py
+++ b/src/pproc/config_generation.py
@@ -69,9 +69,9 @@ def _to_mars(requests: list[dict]) -> str:
         # Reverse source/target keys so request can be used to 
         # create/extract from the input/output files
         if source and source not in ["fdb", "mars", "fdbmars"]:
-            req["target"] = source
+            req["target"] = f"'{source}'"
         elif target and target != "fdb":
-            req["source"] = target
+            req["source"] = f"'{target}'"
         ret += mars.to_mars(b"retrieve", req)
         ret += b"\n"
     return ret.decode("utf-8")

--- a/src/pproc/config_generation.py
+++ b/src/pproc/config_generation.py
@@ -66,11 +66,11 @@ def _to_mars(requests: list[dict]) -> str:
     for req in requests:
         source = req.pop("source", None)
         target = req.pop("target", None)
-        if source and source not in ["fdb", "mars"]:
+        if source and source not in ["fdb", "mars", "fdbmars"]:
             req["target"] = "'{path}'".format(
                 path=source.replace("{", "[").replace("}", "]")
             )
-        elif target and target not in ["fdb", "mars"]:
+        elif target and target != "fdb":
             req["source"] = "'{path}'".format(
                 path=target.replace("{", "[").replace("}", "]")
             )

--- a/src/pproc/config_generation.py
+++ b/src/pproc/config_generation.py
@@ -66,14 +66,12 @@ def _to_mars(requests: list[dict]) -> str:
     for req in requests:
         source = req.pop("source", None)
         target = req.pop("target", None)
+        # Reverse source/target keys so request can be used to 
+        # create/extract from the input/output files
         if source and source not in ["fdb", "mars", "fdbmars"]:
-            req["target"] = "'{path}'".format(
-                path=source.replace("{", "[").replace("}", "]")
-            )
+            req["target"] = source
         elif target and target != "fdb":
-            req["source"] = "'{path}'".format(
-                path=target.replace("{", "[").replace("}", "]")
-            )
+            req["source"] = target
         ret += mars.to_mars(b"retrieve", req)
         ret += b"\n"
     return ret.decode("utf-8")

--- a/src/pproc/config_generation.py
+++ b/src/pproc/config_generation.py
@@ -64,13 +64,13 @@ def from_inputs(args):
 def _to_mars(requests: list[dict]) -> str:
     ret = b""
     for req in requests:
-        source = req.pop("source")
-        target = req.pop("target")
-        if source not in ["fdb", "mars"]:
+        source = req.pop("source", None)
+        target = req.pop("target", None)
+        if source and source not in ["fdb", "mars"]:
             req["target"] = "'{path}'".format(
                 path=source.replace("{", "[").replace("}", "]")
             )
-        elif target not in ["fdb", "mars"]:
+        elif target and target not in ["fdb", "mars"]:
             req["source"] = "'{path}'".format(
                 path=target.replace("{", "[").replace("}", "]")
             )

--- a/src/pproc/quantile/grib.py
+++ b/src/pproc/quantile/grib.py
@@ -28,7 +28,8 @@ def quantiles_metadata(
             }
         )
     else:
-        grib_keys.setdefault("productDefinitionTemplateNumber", 86)
+        product_template_number = 87 if "stepRange" in out_keys else 86
+        grib_keys.setdefault("productDefinitionTemplateNumber", product_template_number)
         grib_keys.update(
             {
                 "totalNumberOfQuantiles": total_number,


### PR DESCRIPTION
### Description
- Use filepaths in sources and targets to correctly set the `target`/`source` in input/output mars requests, respectively
- Remove duplicates from ecpoint inputs
- Set quantile grib 2 `productDefintionTemplateNumber` depending on step accumulation

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 