### PR TITLE
Support combined probabilities involving different params

### DIFF
--- a/src/pproc/prob/accumulation_manager.py
+++ b/src/pproc/prob/accumulation_manager.py
@@ -13,6 +13,7 @@ import numpy as np
 from pproc.common.accumulation import Accumulator, coords_name
 from pproc.common.accumulation_manager import AccumulationManager
 from pproc.config.accumulation import accumulation_factory
+from pproc.prob.threshold import ThresholdConfig
 
 
 class ThresholdAccumulationManager(AccumulationManager):
@@ -23,7 +24,7 @@ class ThresholdAccumulationManager(AccumulationManager):
     :raises: RuntimeError if no window operation was provided, or could be derived
     """
 
-    _thresholds: dict
+    _thresholds: dict[str, list[ThresholdConfig]]
 
     @classmethod
     def create(cls, config: Dict[str, dict], grib_keys: Optional[dict] = None):
@@ -43,10 +44,12 @@ class ThresholdAccumulationManager(AccumulationManager):
         for accum_name in mgr.accumulations.keys():
             dims = accum_name.split(":")
             step_name = [x for x in dims if "step" in x][0]
-            mgr._thresholds[accum_name] = all_thresholds[step_name]
+            mgr._thresholds[accum_name] = [
+                ThresholdConfig(**x) for x in all_thresholds[step_name]
+            ]
         return mgr
 
-    def thresholds(self, identifier: str) -> dict:
+    def thresholds(self, identifier: str) -> list[ThresholdConfig]:
         """
         Returns thresholds for window and deletes window from window:threshold dictionary
         """

--- a/src/pproc/prob/parallel.py
+++ b/src/pproc/prob/parallel.py
@@ -31,10 +31,7 @@ def ensemble_probability(data: np.array, thconfig: ThresholdConfig) -> np.array:
 
     """
     thresholds = thconfig.param_thresholds
-    num_params = len(thresholds)
-    data = data.reshape(
-        (num_params, round(data.shape[0] / num_params)) + data.shape[1:]
-    )
+    data = data.reshape((len(thresholds), -1) + data.shape[1:])
     is_nan = 0
     comp = 1
     for index, threshold in enumerate(thresholds):

--- a/src/pproc/prob/parallel.py
+++ b/src/pproc/prob/parallel.py
@@ -76,7 +76,9 @@ def prob_iteration(
             grib_set = out_prob.metadata.copy()
             grib_set.update(accum.grib_keys())
             grib_set.update(
-                threshold.grib_keys(grib_set.get("edition", 1), clim_metadata)
+                threshold.grib_keys(
+                    grib_set.get("edition", template["edition"]), clim_metadata
+                )
             )
             write_grib(out_prob.target, template, window_probability, grib_set)
 

--- a/src/pproc/prob/parallel.py
+++ b/src/pproc/prob/parallel.py
@@ -8,7 +8,7 @@
 # nor does it submit to any jurisdiction.
 
 from meters import ResourceMeter
-from typing import Dict, Optional
+from typing import Union, Optional
 import numpy as np
 import numexpr
 
@@ -19,64 +19,10 @@ from pproc.config.io import Output
 from pproc.config.recovery import BaseRecovery
 from pproc.common.accumulation import Accumulator
 from pproc.common.io import write_grib
+from pproc.prob.threshold import ThresholdConfig
 
 
-def threshold_grib_headers(
-    edition: int, threshold: Dict, clim_metadata: Optional[Dict] = None
-) -> Dict:
-    """
-    Creates dictionary of threshold related grib headers
-    """
-    threshold_dict = {"paramId": threshold["out_paramid"]}
-    scale_factor = threshold.get("local_scale_factor", 0)
-    threshold_value = round(threshold["value"] * 10**scale_factor, 0)
-    comparison = threshold["comparison"].strip("=")
-    if edition == 1 and comparison == "<":
-        grib_keys = {
-            "localDefinitionNumber": 5,
-            "localDecimalScaleFactor": scale_factor,
-            "thresholdIndicator": 2,
-            "upperThreshold": threshold_value,
-        }
-    elif edition == 1 and comparison == ">":
-        grib_keys = {
-            "localDefinitionNumber": 5,
-            "localDecimalScaleFactor": scale_factor,
-            "thresholdIndicator": 1,
-            "lowerThreshold": threshold_value,
-        }
-    elif edition == 2:
-        # GRIB 2 has probability types above/below upper/lower limits (see Code Table 4.9)
-        # where the threshold value can correspond to either limit. The default limit type
-        # is upper for "<" and lower for ">", consistent with the GRIB 1 to GRIB 2 conversion
-        # assumption.
-        prob_types = {"<": {"upper": 4, "lower": 0}, ">": {"upper": 1, "lower": 3}}
-        if comparison == "<":
-            limit_type = threshold.get("limit_type", "upper")
-            probability_type = prob_types[comparison][limit_type]
-        elif comparison == ">":
-            limit_type = threshold.get("limit_type", "lower")
-            probability_type = prob_types[comparison][limit_type]
-        missing = "Upper" if limit_type == "lower" else "Lower"
-        grib_keys = {
-            f"scaleFactorOf{limit_type.capitalize()}Limit": scale_factor,
-            f"scaledValueOf{limit_type.capitalize()}Limit": threshold_value,
-            "probabilityType": probability_type,
-            f"scaleFactorOf{missing}Limit": "MISSING",
-            f"scaledValueOf{missing}Limit": "MISSING",
-        }
-        if clim_metadata:
-            grib_keys.update(clim_metadata)
-    else:
-        raise ValueError(
-            f"Unsupported threshold comparison {comparison} for grib edition {edition}"
-        )
-
-    threshold_dict.update(grib_keys)
-    return threshold_dict
-
-
-def ensemble_probability(data: np.array, threshold: Dict) -> np.array:
+def ensemble_probability(data: np.array, thconfig: ThresholdConfig) -> np.array:
     """Ensemble Probabilities:
 
     Computes the probability of a given parameter crossing a given threshold,
@@ -84,20 +30,27 @@ def ensemble_probability(data: np.array, threshold: Dict) -> np.array:
     e.g. the chance of temperature being less than 0C
 
     """
-
-    # Find all locations where np.nan appears as an ensemble value
-    is_nan = np.isnan(data).any(axis=0)
-
-    # Read threshold configuration and compute probability
-    comparison = threshold["comparison"]
-    comp = numexpr.evaluate(
-        "data " + comparison + str(threshold["value"]), local_dict={"data": data}
+    thresholds = thconfig.param_thresholds
+    num_params = len(thresholds)
+    data = data.reshape(
+        (num_params, round(data.shape[0] / num_params)) + data.shape[1:]
     )
-    probability = np.where(comp, 100, 0).mean(axis=0)
+    is_nan = 0
+    comp = 1
+    for index, threshold in enumerate(thresholds):
+        param_data = data[index]
+        # Find all locations where np.nan appears as an ensemble value
+        is_nan |= np.isnan(param_data).any(axis=0)
 
+        # Read threshold configuration and compute probability
+        comp &= numexpr.evaluate(
+            "data " + threshold.comparison + str(threshold.value),
+            local_dict={"data": param_data},
+        )
+
+    probability = np.where(comp, 100, 0).mean(axis=0)
     # Put in missing values
     probability = np.where(is_nan, np.nan, probability)
-
     return probability
 
 
@@ -108,7 +61,7 @@ def prob_iteration(
     template: eccodes.GRIBMessage,
     window_id: str,
     accum: Accumulator,
-    thresholds: list,
+    thresholds: list[ThresholdConfig],
     clim_metadata: Optional[dict] = None,
 ):
     with ResourceMeter(f"Window {window_id}, computing threshold probs"):
@@ -121,16 +74,13 @@ def prob_iteration(
 
             print(
                 f"Writing probability for input param {param.name} and output "
-                + f"param {threshold['out_paramid']} for step(s) {window_id}"
+                + f"param {threshold.out_paramid} for step(s) {window_id}"
             )
             grib_set = out_prob.metadata.copy()
             grib_set.update(accum.grib_keys())
             grib_set.update(
-                threshold_grib_headers(
-                    grib_set.get("edition", 1), threshold, clim_metadata
-                )
+                threshold.grib_keys(grib_set.get("edition", 1), clim_metadata)
             )
-            grib_set.update(threshold.get("metadata", {}))
             write_grib(out_prob.target, template, window_probability, grib_set)
 
         out_prob.target.flush()

--- a/src/pproc/prob/threshold.py
+++ b/src/pproc/prob/threshold.py
@@ -1,0 +1,71 @@
+from pydantic import BaseModel, model_validator
+from typing import Union, Any, Optional
+
+
+class Threshold(BaseModel):
+    comparison: str
+    value: float
+
+
+class ThresholdConfig(BaseModel):
+    out_paramid: int
+    local_scale_factor: int = 0
+    param_thresholds: list[Threshold]
+    metadata: dict = {}
+    limit_type: str = "lower"
+
+    @model_validator(mode="before")
+    def validate_thresholds(cls, data: Any) -> Any:
+        if isinstance(data, dict) and "param_thresholds" not in data:
+            value = data.pop("value")
+            comparison = data.pop("comparison")
+            data["param_thresholds"] = [{"value": value, "comparison": comparison}]
+        return data
+
+    def grib_keys(self, edition: int, clim_metadata: Optional[dict] = None) -> dict:
+        """
+        Creates dictionary of threshold related grib headers
+        """
+        threshold_dict = {"paramId": self.out_paramid}
+        scale_factor = self.local_scale_factor
+        threshold_value = round(self.param_thresholds[0].value * 10**scale_factor, 0)
+        comparison = self.param_thresholds[0].comparison.strip("=")
+        if edition == 1 and comparison == "<":
+            grib_keys = {
+                "localDefinitionNumber": 5,
+                "localDecimalScaleFactor": scale_factor,
+                "thresholdIndicator": 2,
+                "upperThreshold": threshold_value,
+            }
+        elif edition == 1 and comparison == ">":
+            grib_keys = {
+                "localDefinitionNumber": 5,
+                "localDecimalScaleFactor": scale_factor,
+                "thresholdIndicator": 1,
+                "lowerThreshold": threshold_value,
+            }
+        elif edition == 2:
+            # GRIB 2 has probability types above/below upper/lower limits (see Code Table 4.9)
+            # where the threshold value can correspond to either limit. The default limit type
+            # is upper for "<" and lower for ">", consistent with the GRIB 1 to GRIB 2 conversion
+            # assumption.
+            prob_types = {"<": {"upper": 4, "lower": 0}, ">": {"upper": 1, "lower": 3}}
+            probability_type = prob_types[comparison][self.limit_type]
+            missing = "Upper" if self.limit_type == "lower" else "Lower"
+            grib_keys = {
+                f"scaleFactorOf{self.limit_type.capitalize()}Limit": scale_factor,
+                f"scaledValueOf{self.limit_type.capitalize()}Limit": threshold_value,
+                "probabilityType": probability_type,
+                f"scaleFactorOf{missing}Limit": "MISSING",
+                f"scaledValueOf{missing}Limit": "MISSING",
+            }
+            if clim_metadata:
+                grib_keys.update(clim_metadata)
+        else:
+            raise ValueError(
+                f"Unsupported threshold comparison {comparison} for grib edition {edition}"
+            )
+
+        threshold_dict.update(grib_keys)
+        threshold_dict.update(self.metadata)
+        return threshold_dict

--- a/tests/prob/test_prob_accumulation_manager.py
+++ b/tests/prob/test_prob_accumulation_manager.py
@@ -18,6 +18,7 @@ from pproc.common.accumulation import (
 from pproc.prob.accumulation_manager import (
     ThresholdAccumulationManager,
 )
+from pproc.prob.threshold import ThresholdConfig
 
 
 @pytest.mark.parametrize(
@@ -30,7 +31,11 @@ from pproc.prob.accumulation_manager import (
                     {
                         "operation": "minimum",
                         "thresholds": [
-                            {"comparison": "<=", "value": 273.15},
+                            {
+                                "out_paramid": 131073,
+                                "comparison": "<=",
+                                "value": 273.15,
+                            },
                         ],
                         "coords": [
                             {"from": 120, "to": 240, "by": 6},
@@ -44,7 +49,11 @@ from pproc.prob.accumulation_manager import (
             {
                 f"step_{a}-{b}_0": (
                     SimpleAccumulation,
-                    [{"comparison": "<=", "value": 273.15}],
+                    [
+                        ThresholdConfig(
+                            out_paramid=131073, comparison="<=", value=273.15
+                        )
+                    ],
                 )
                 for a, b in [(120, 240), (120, 168), (168, 240), (240, 360)]
             },
@@ -58,9 +67,9 @@ from pproc.prob.accumulation_manager import (
                     {
                         "operation": "maximum",
                         "thresholds": [
-                            {"comparison": ">=", "value": 15},
-                            {"comparison": ">=", "value": 20},
-                            {"comparison": ">=", "value": 25},
+                            {"out_paramid": 131073, "comparison": ">=", "value": 15},
+                            {"out_paramid": 131073, "comparison": ">=", "value": 20},
+                            {"out_paramid": 131073, "comparison": ">=", "value": 25},
                         ],
                         "coords": [
                             {"from": 0, "to": 24, "by": 6},
@@ -74,9 +83,15 @@ from pproc.prob.accumulation_manager import (
                 f"step_{a}-{b}_0": (
                     SimpleAccumulation,
                     [
-                        {"comparison": ">=", "value": 15.0},
-                        {"comparison": ">=", "value": 20.0},
-                        {"comparison": ">=", "value": 25.0},
+                        ThresholdConfig(
+                            out_paramid=131073, comparison=">=", value=15.0
+                        ),
+                        ThresholdConfig(
+                            out_paramid=131073, comparison=">=", value=20.0
+                        ),
+                        ThresholdConfig(
+                            out_paramid=131073, comparison=">=", value=25.0
+                        ),
                     ],
                 )
                 for a, b in [(0, 24), (12, 36), (336, 360)]
@@ -91,19 +106,19 @@ from pproc.prob.accumulation_manager import (
                     {
                         "operation": "difference",
                         "thresholds": [
-                            {"comparison": ">=", "value": 0.001},
-                            {"comparison": ">=", "value": 0.005},
-                            {"comparison": ">=", "value": 0.01},
-                            {"comparison": ">=", "value": 0.02},
+                            {"out_paramid": 131073, "comparison": ">=", "value": 0.001},
+                            {"out_paramid": 131073, "comparison": ">=", "value": 0.005},
+                            {"out_paramid": 131073, "comparison": ">=", "value": 0.01},
+                            {"out_paramid": 131073, "comparison": ">=", "value": 0.02},
                         ],
                         "coords": [[0, 24], [12, 36], [336, 360]],
                     },
                     {
                         "operation": "difference",
                         "thresholds": [
-                            {"comparison": ">=", "value": 0.025},
-                            {"comparison": ">=", "value": 0.05},
-                            {"comparison": ">=", "value": 0.1},
+                            {"out_paramid": 131073, "comparison": ">=", "value": 0.025},
+                            {"out_paramid": 131073, "comparison": ">=", "value": 0.05},
+                            {"out_paramid": 131073, "comparison": ">=", "value": 0.1},
                         ],
                         "coords": [[0, 24], [12, 36], [336, 360]],
                     },
@@ -111,9 +126,9 @@ from pproc.prob.accumulation_manager import (
                         "operation": "difference_rate",
                         "factor": 1.0 / 24.0,
                         "thresholds": [
-                            {"comparison": "<", "value": 0.001},
-                            {"comparison": ">=", "value": 0.003},
-                            {"comparison": ">=", "value": 0.005},
+                            {"out_paramid": 131073, "comparison": "<", "value": 0.001},
+                            {"out_paramid": 131073, "comparison": ">=", "value": 0.003},
+                            {"out_paramid": 131073, "comparison": ">=", "value": 0.005},
                         ],
                         "coords": [[120, 240], [168, 240], [228, 360]],
                     },
@@ -123,7 +138,12 @@ from pproc.prob.accumulation_manager import (
                 **{
                     f"step_{a}-{b}_{i}": (
                         Difference,
-                        [{"comparison": ">=", "value": thr} for thr in thrs],
+                        [
+                            ThresholdConfig(
+                                out_paramid=131073, comparison=">=", value=thr
+                            )
+                            for thr in thrs
+                        ],
                     )
                     for i, thrs in enumerate(
                         [[0.001, 0.005, 0.01, 0.02], [0.025, 0.05, 0.1]]
@@ -134,7 +154,9 @@ from pproc.prob.accumulation_manager import (
                     f"step_{a}-{b}_2": (
                         DifferenceRate,
                         [
-                            {"comparison": cmp, "value": val}
+                            ThresholdConfig(
+                                out_paramid=131073, comparison=cmp, value=val
+                            )
                             for cmp, vals in [("<", [0.001]), (">=", [0.003, 0.005])]
                             for val in vals
                         ],
@@ -152,8 +174,8 @@ from pproc.prob.accumulation_manager import (
                     {
                         "operation": "mean",
                         "thresholds": [
-                            {"comparison": "<", "value": -2},
-                            {"comparison": ">=", "value": 2},
+                            {"out_paramid": 131073, "comparison": "<", "value": -2},
+                            {"out_paramid": 131073, "comparison": ">=", "value": 2},
                         ],
                         "coords": [
                             {"from": 120, "to": 168, "by": 12},
@@ -167,8 +189,8 @@ from pproc.prob.accumulation_manager import (
                 f"step_{a}-{b}_0": (
                     Mean,
                     [
-                        {"comparison": "<", "value": -2},
-                        {"comparison": ">=", "value": 2},
+                        ThresholdConfig(out_paramid=131073, comparison="<", value=-2),
+                        ThresholdConfig(out_paramid=131073, comparison=">=", value=2),
                     ],
                 )
                 for a, b in [(120, 168), (168, 240), (240, 360)]
@@ -203,24 +225,24 @@ def test_create_threshold(config, expected, exp_coords):
                     {
                         "operation": "minimum",
                         "thresholds": [
-                            {"comparison": "<", "value": -8},
-                            {"comparison": "<", "value": -4},
+                            {"out_paramid": 131073, "comparison": "<", "value": -8},
+                            {"out_paramid": 131073, "comparison": "<", "value": -4},
                         ],
                         "coords": [[0], [12], [360]],
                     },
                     {
                         "operation": "maximum",
                         "thresholds": [
-                            {"comparison": ">", "value": 4},
-                            {"comparison": ">", "value": 8},
+                            {"out_paramid": 131073, "comparison": ">", "value": 4},
+                            {"out_paramid": 131073, "comparison": ">", "value": 8},
                         ],
                         "coords": [[0], [12], [360]],
                     },
                     {
                         "operation": "mean",
                         "thresholds": [
-                            {"comparison": "<", "value": -4},
-                            {"comparison": ">=", "value": 2},
+                            {"out_paramid": 131073, "comparison": "<", "value": -4},
+                            {"out_paramid": 131073, "comparison": ">=", "value": 2},
                         ],
                         "coords": [
                             {"from": 120, "to": 240, "by": 12},
@@ -231,7 +253,7 @@ def test_create_threshold(config, expected, exp_coords):
                         "operation": "maximum",
                         "std_anomaly": True,
                         "thresholds": [
-                            {"comparison": ">", "value": 1},
+                            {"out_paramid": 131073, "comparison": ">", "value": 1},
                         ],
                         "coords": [[0], [12], [300]],
                     },
@@ -239,7 +261,7 @@ def test_create_threshold(config, expected, exp_coords):
                         "operation": "minimum",
                         "std_anomaly": True,
                         "thresholds": [
-                            {"comparison": "<", "value": -1.5},
+                            {"out_paramid": 131073, "comparison": "<", "value": -1.5},
                         ],
                         "coords": [[0], [12], [300]],
                     },
@@ -249,7 +271,12 @@ def test_create_threshold(config, expected, exp_coords):
                 **{
                     f"step_{s}_{index}": (
                         SimpleAccumulation,
-                        [{"comparison": cmp, "value": val} for val in vals],
+                        [
+                            ThresholdConfig(
+                                out_paramid=131073, comparison=cmp, value=val
+                            )
+                            for val in vals
+                        ],
                     )
                     for index, (cmp, op, vals) in enumerate(
                         [
@@ -263,8 +290,12 @@ def test_create_threshold(config, expected, exp_coords):
                     f"step_{a}-{b}_2": (
                         Mean,
                         [
-                            {"comparison": "<", "value": -4},
-                            {"comparison": ">=", "value": 2},
+                            ThresholdConfig(
+                                out_paramid=131073, comparison="<", value=-4
+                            ),
+                            ThresholdConfig(
+                                out_paramid=131073, comparison=">=", value=2
+                            ),
                         ],
                     )
                     for a, b in [(120, 240), (336, 360)]
@@ -272,7 +303,11 @@ def test_create_threshold(config, expected, exp_coords):
                 **{
                     f"step_STDANOM_{s}_{index + 3}": (
                         SimpleAccumulation,
-                        [{"comparison": cmp, "value": val}],
+                        [
+                            ThresholdConfig(
+                                out_paramid=131073, comparison=cmp, value=val
+                            )
+                        ],
                     )
                     for index, (cmp, op, val) in enumerate(
                         [

--- a/tests/templates/t850.yaml
+++ b/tests/templates/t850.yaml
@@ -76,7 +76,6 @@ parameters:
           - out_paramid: 133096
             comparison: <
             value: -1
-            limit_type: lower
           metadata:
             localDefinitionNumber: 30
             bitsPerValue: 24


### PR DESCRIPTION
### Description
- Adapt threshold configuration to allow specification of thresholds for different parameters and probability computation to combine thresholds into single probability
- Modify grib 2 probability keys to use lower limit type as default, as specified by dgov

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 