### PR TITLE
Fix append number in output request generation

### DIFF
--- a/src/pproc/config/base.py
+++ b/src/pproc/config/base.py
@@ -237,7 +237,7 @@ class BaseConfig(ConfigModel):
             elif number != src_req["number"]:
                 raise ValueError("Inconsistent number of members in input requests")
 
-        number = to_list(number)
+        number = [] if number is None else to_list(number)
         if len(number) == num_members - 1:
             number = [0] + number
         req["number"] = number


### PR DESCRIPTION
### Description
Fix that sets `number = 0` in output request generation if `number` is required and doesn't exist in input requests

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 