### PR TITLE
Fix setting of `number` in output request for ecpoint

### DIFF
--- a/src/pproc/config/types.py
+++ b/src/pproc/config/types.py
@@ -1087,7 +1087,6 @@ class ECPointConfig(QuantilesConfig):
             return req
 
         req.pop("quantile")
-        # Consult inputs for setting of number
         self._append_number(param, req)
         return req
 

--- a/src/pproc/config/types.py
+++ b/src/pproc/config/types.py
@@ -1066,6 +1066,20 @@ class ECPointConfig(QuantilesConfig):
             return {}
         return super()._populate_accumulations(inputs, base_accum)
 
+    def _append_number(self, param: ParamConfig, req: dict):
+        src_name = self.inputs.names[0]
+        inputs = param.input_list(self.inputs, src_name)
+        src_reqs = inputs[0].request
+        if isinstance(src_reqs, dict):
+            src_reqs = [src_reqs]
+
+        # Inherit number from matching source
+        for src_req in src_reqs:
+            if src_req["stream"] != req["stream"] or "number" not in src_req:
+                continue
+            req["number"] = src_req["number"]
+            break
+
     def _format_out(self, param: ParamConfig, req) -> dict:
         req = super()._format_out(param, req)
         req["model"] = "ecPoint"
@@ -1073,6 +1087,7 @@ class ECPointConfig(QuantilesConfig):
             return req
 
         req.pop("quantile")
+        # Consult inputs for setting of number
         self._append_number(param, req)
         return req
 


### PR DESCRIPTION
### Description
For weather types and bias-corrected values, it was raised by dgov that we do not use the same stream for unperturbed and perturbed members. The stream is inherited from the inputs and this PR ensures that the `number` key is also inherited from the inputs.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 