### PR TITLE
Fix derivation of monthly output step ranges

### DIFF
--- a/src/pproc/schema/step.py
+++ b/src/pproc/schema/step.py
@@ -66,6 +66,8 @@ class Monthly(BaseModel):
 
     def generate_steps(self, steps: list[int]) -> list[str]:
         by = np.diff(steps)
+        if len(by) == 0:
+            return []
         if len(set(by)) != 1:
             raise ValueError("Monthly steps must be evenly spaced")
         return [

--- a/src/pproc/schema/step.py
+++ b/src/pproc/schema/step.py
@@ -52,11 +52,10 @@ class Range(BaseModel):
             isinstance(x, int) for x in steps
         ), "Steps can not be a mix of strings and integers"
         start = self.start or steps[0]
-        end = self.end or steps[-1]
-        return [
-            f"{rstart}-{rstart + self.width}"
-            for rstart in range(start, end - self.width + 1, self.interval)
-        ]
+        end = min((self.end or steps[-1]), steps[-1]) - self.width + 1
+        rstarts = set(range(start, end + 1, self.interval))
+        rstarts.intersection_update(steps)
+        return [f"{rstart}-{rstart + self.width}" for rstart in sorted(rstarts)]
 
 
 class Monthly(BaseModel):
@@ -64,7 +63,7 @@ class Monthly(BaseModel):
     date: str
     dim: Literal["fcmonth"] = "fcmonth"
 
-    def generate_steps(self, steps: list[int]) -> list[str]:
+    def generate_steps(self, steps: list[int]) -> list[int]:
         by = np.diff(steps)
         if len(by) == 0:
             return []

--- a/src/pproc/schema/step.py
+++ b/src/pproc/schema/step.py
@@ -52,7 +52,7 @@ class Range(BaseModel):
             isinstance(x, int) for x in steps
         ), "Steps can not be a mix of strings and integers"
         start = self.start or steps[0]
-        end = min((self.end or steps[-1]), steps[-1]) - self.width + 1
+        end = min((self.end or steps[-1]), steps[-1]) - self.width
         rstarts = set(range(start, end + 1, self.interval))
         rstarts.intersection_update(steps)
         return [f"{rstart}-{rstart + self.width}" for rstart in sorted(rstarts)]

--- a/tests/schema/test_step_schema.py
+++ b/tests/schema/test_step_schema.py
@@ -28,6 +28,11 @@ from conftest import schema
             ["0-6", "3-9"],
         ],
         [
+            {"type": "range", "interval": 1, "width": 1},
+            list(range(0, 5)),
+            ["0-1", "1-2", "2-3", "3-4"],
+        ],
+        [
             {"type": "range", "start": 2, "end": 8, "interval": 2, "width": 2},
             list(range(0, 7)),
             ["2-4", "4-6"],

--- a/tests/schema/test_step_schema.py
+++ b/tests/schema/test_step_schema.py
@@ -9,9 +9,42 @@
 
 import pytest
 
-from pproc.schema.step import StepSchema
+from pproc.schema.step import StepType, StepSchema
 
 from conftest import schema
+
+
+@pytest.mark.parametrize(
+    "config, steps, expected",
+    [
+        [{"type": "instantaneous"}, [0, 1, 2], [0, 1, 2]],
+        [{"type": "instantaneous", "deaccumulate": True}, [0, 1, 2], [1, 2]],
+        [{"type": "instantaneous", "start": 1, "end": 2}, [0, 1, 2, 3], [1, 2]],
+        [{"type": "instantaneous", "interval": 2}, [0, 1, 2, 3, 4], [0, 2, 4]],
+        [{"type": "instantaneous", "start": 3, "end": 6}, [0, 1, 2], []],
+        [
+            {"type": "range", "interval": 3, "width": 6},
+            list(range(0, 10)),
+            ["0-6", "3-9"],
+        ],
+        [
+            {"type": "range", "start": 2, "end": 8, "interval": 2, "width": 2},
+            list(range(0, 7)),
+            ["2-4", "4-6"],
+        ],
+        [
+            {"type": "range", "start": 12, "end": 24, "interval": 2, "width": 4},
+            list(range(0, 10)),
+            [],
+        ],
+        [{"type": "monthly", "date": "20240601"}, list(range(0, 800)), [1]],
+        [{"type": "monthly", "date": "20240601"}, list(range(0, 500)), []],
+        [{"type": "monthly", "date": "20240601"}, [0], []],
+    ],
+)
+def test_step_type(config, steps, expected):
+    step_type = StepType(**config).root
+    assert step_type.generate_steps(steps) == expected
 
 
 def test_in_steps():


### PR DESCRIPTION
### Description
- Handle single step in derivation of monthly step ranges from input steps
- Tighten output step range derivation to only return those compatible with input steps
- Add tests

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 