### PR TITLE
Fix warning message in `DefaultStepDeriver`

### DIFF
--- a/src/pproc/schema/deriver.py
+++ b/src/pproc/schema/deriver.py
@@ -27,7 +27,7 @@ class DefaultStepDeriver(BaseModel):
 
     def _inst_step(self, step: int, fc_steps: list[int]) -> list[int]:
         if step not in fc_steps:
-            raise ValueError(f"Required step {start} not in forecast steps")
+            raise ValueError(f"Required step {step} not in forecast steps")
         return [step]
 
     def _range(self, start: int, end: int, fc_steps: list[int]) -> tuple[int]:


### PR DESCRIPTION
### Description
Fix undefined variable used in `DefaultStepDeriver. _inst_step ` warning message in 

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 