### PR TITLE
Fix merging of thermofeel configs

### DIFF
--- a/src/pproc/config/param.py
+++ b/src/pproc/config/param.py
@@ -21,7 +21,7 @@ from pydantic import BaseModel, Field, model_validator
 from pproc.config.preprocessing import PreprocessingConfig
 from pproc.config.accumulation import AccumulationConfig
 from pproc.config.utils import extract_mars, deep_update
-from pproc.config.io import Input, InputsCollection
+from pproc.config.io import Source, Input, InputsCollection
 from pproc.config.utils import update_request, expand
 
 logger = logging.getLogger(__name__)
@@ -43,6 +43,15 @@ class ParamConfig(BaseModel):
     total_fields: int = 0
     vod2uv: bool = False
     _merge_exclude: tuple[str] = ("accumulations",)
+
+    @model_validator(mode="after")
+    def validate_inputs(self) -> Self:
+        for src_name, src_config in self.inputs.items():
+            if "source" in src_config:
+                self.inputs[src_name]["source"] = Source.validate_source(
+                    src_config["source"]
+                )
+        return self
 
     @model_validator(mode="after")
     def set_vod2uv(self) -> Self:

--- a/src/pproc/config/types.py
+++ b/src/pproc/config/types.py
@@ -864,7 +864,7 @@ class ThermoConfig(BaseConfig):
     parameters: list[ThermoParamConfig]
     validateutci: bool = False
     utci_misses: bool = False
-    _merge_exclude: tuple[str] = ("parameters", "inputs")
+    _merge_exclude: tuple[str] = ("parameters",)
 
     @model_validator(mode="after")
     def check_params(self) -> Self:
@@ -885,6 +885,10 @@ class ThermoConfig(BaseConfig):
         for out_name in io.ThermoOutputModel.names:
             if out_name != "indices" and out_name not in outputs:
                 outputs["out_name"] = {"target": {"type": "null"}}
+
+        overrides.setdefault("inputs", {}).setdefault("accum", {}).setdefault(
+            "source", "null:"
+        )
         return super().from_schema(schema_config, **overrides)
 
     @model_validator(mode="after")
@@ -913,6 +917,13 @@ class ThermoConfig(BaseConfig):
             sorted_requests.setdefault(src_name, []).append(inp)
         return sorted_requests
 
+    @classmethod
+    def _populate_inputs(
+        cls, inputs: list[dict], accum_dims: list[str], **overrides
+    ) -> dict:
+        overrides.setdefault("accum", {}).setdefault("source", "fdb:")
+        return super()._populate_inputs(inputs, accum_dims, **overrides)
+
     def _merge_parameters(self, other: Self = None) -> list[ThermoParamConfig]:
         merged_params = [self.parameters[0]]
         other_params = self.parameters[1:]
@@ -928,21 +939,6 @@ class ThermoConfig(BaseConfig):
             if not merged:
                 merged_params.append(in_param)
         return merged_params
-
-    def _merge_inputs(self, other: Self) -> io.ThermoInputModel:
-        new_inputs = self.inputs.model_copy()
-        other_inputs = other.inputs.model_copy()
-        if new_inputs.accum.type == "null":
-            new_inputs.accum.type = other_inputs.accum.type
-            new_inputs.accum.path = other_inputs.accum.path
-        if other_inputs.accum.type == "null" and new_inputs.accum.type != "null":
-            other_inputs.accum.type = new_inputs.accum.type
-            other_inputs.accum.path = new_inputs.accum.path
-        if new_inputs != other_inputs:
-            raise ValueError(
-                "Can only merge configs with inputs differing by accum input type"
-            )
-        return new_inputs
 
     def _format_out(self, param: ParamConfig, req) -> dict:
         req = super()._format_out(param, req)

--- a/tests/config/test_factory.py
+++ b/tests/config/test_factory.py
@@ -700,3 +700,81 @@ def test_wind():
             [],
         ),
     )
+
+
+@pytest.mark.parametrize(
+    "updates, has_accum",
+    [
+        [
+            [
+                {
+                    "param": [
+                        261002,
+                        261001,
+                        260004,
+                        260005,
+                        260255,
+                        260242,
+                        261016,
+                        261018,
+                        261015,
+                        261014,
+                        261023,
+                    ],
+                    "step": [1, 2],
+                }
+            ],
+            [True],
+        ],
+        [
+            [
+                {
+                    "param": [
+                        261002,
+                        261001,
+                        260004,
+                        260005,
+                        260255,
+                        260242,
+                        261016,
+                        261018,
+                        261015,
+                        261014,
+                        261023,
+                    ],
+                    "step": [1, 2],
+                },
+                {"param": [260242], "step": [0]},
+            ],
+            [True, False],
+        ],
+        [
+            [
+                {
+                    "param": [260004, 260242, 261016, 260005, 260255, 261018],
+                    "step": [0, 1, 2],
+                }
+            ],
+            [False],
+        ],
+    ],
+)
+def test_thermofeel_merge(updates, has_accum):
+    test_schema = Schema(**schema())
+    base_request = {
+        **DEFAULT_REQUEST,
+        "levtype": "sfc",
+        "type": "pf",
+        "number": [1, 2, 3],
+    }
+    overrides = {
+        "inputs": {"inst": {"source": "mars:"}},
+        "parameters": {"default": {"inputs": {"accum": {"source": "mars:"}}}},
+    }
+    config = ConfigFactory.from_outputs(
+        test_schema, [{**base_request, **req} for req in updates], **overrides
+    )
+    assert len(config.parameters) == len(has_accum)
+    assert config.inputs.accum.source.type_ == "null"
+    for param, accum in zip(config.parameters, has_accum):
+        assert param.inputs.get("accum", None) is not None if accum else True


### PR DESCRIPTION
### Description
Fixes bug on merging thermofeel configs for parameters that required `inst` and `accum` inputs and those which only required `inst` input. Now in config generation, by default set `accum` source in global `inputs` config to null and this is overridden inside the parameter config by those which required accum inputs.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 