### PR TITLE
Remove `model` specification for ecpoint

### DIFF
--- a/src/pproc/config/types.py
+++ b/src/pproc/config/types.py
@@ -1073,12 +1073,16 @@ class ECPointConfig(QuantilesConfig):
         if isinstance(src_reqs, dict):
             src_reqs = [src_reqs]
 
-        # Inherit number from matching source
+        # Inherit number from sources with matching stream
+        number = []
         for src_req in src_reqs:
-            if src_req["stream"] != req["stream"] or "number" not in src_req:
-                continue
-            req["number"] = src_req["number"]
-            break
+            if src_req["stream"] == req["stream"]:
+                if src_req["type"] == "cf":
+                    number += [0]
+                else:
+                    number += src_req.get("number", [])
+        if len(number) != 0:
+            req["number"] = number
 
     def _format_out(self, param: ParamConfig, req) -> dict:
         req = super()._format_out(param, req)

--- a/src/pproc/config/types.py
+++ b/src/pproc/config/types.py
@@ -1082,7 +1082,7 @@ class ECPointConfig(QuantilesConfig):
 
     def _format_out(self, param: ParamConfig, req) -> dict:
         req = super()._format_out(param, req)
-        req["model"] = "ecPoint"
+        req["method"] = "ecPoint"
         if req["type"] == "pfc":
             return req
 

--- a/src/pproc/config/types.py
+++ b/src/pproc/config/types.py
@@ -1086,7 +1086,6 @@ class ECPointConfig(QuantilesConfig):
 
     def _format_out(self, param: ParamConfig, req) -> dict:
         req = super()._format_out(param, req)
-        req["method"] = "ecPoint"
         if req["type"] == "pfc":
             return req
 

--- a/src/pproc/ecpoint.py
+++ b/src/pproc/ecpoint.py
@@ -82,7 +82,14 @@ def grid_bc_metadata(
                 "timeIncrement": 1,
             }
         )
-    grib_keys.update(out_keys)
+        grib_keys.update(out_keys)
+        if grib_keys["productDefinitionTemplateNumber"] == 73:
+            if template.get("number", 0) == 0:
+                grib_keys["typeOfEnsembleForecast"] = 5
+            else:
+                grib_keys["typeOfEnsembleForecast"] = 6
+    else:
+        grib_keys.update(out_keys)
     return template, grib_keys
 
 
@@ -118,7 +125,14 @@ def weather_types_metadata(
                 "timeIncrement": 1,
             }
         )
-    grib_keys.update(out_keys)
+        grib_keys.update(out_keys)
+        if grib_keys["productDefinitionTemplateNumber"] == 73:
+            if template.get("number", 0) == 0:
+                grib_keys["typeOfEnsembleForecast"] = 5
+            else:
+                grib_keys["typeOfEnsembleForecast"] = 6
+    else:
+        grib_keys.update(out_keys)
     return template, grib_keys
 
 
@@ -356,7 +370,9 @@ def main():
                 },
             )
         ]
-        checkpointed_windows = [x["window"] for x in cfg.recovery.computed(param=param.name)]
+        checkpointed_windows = [
+            x["window"] for x in cfg.recovery.computed(param=param.name)
+        ]
         managers[0].delete(checkpointed_windows)
         requesters = [
             FilteredParamRequester(

--- a/src/pproc/ecpoint.py
+++ b/src/pproc/ecpoint.py
@@ -84,7 +84,8 @@ def grid_bc_metadata(
         )
         grib_keys.update(out_keys)
         if grib_keys["productDefinitionTemplateNumber"] == 73:
-            if template.get("number", 0) == 0:
+            mars_keys = {k: v for k, v in template.items(namespace="mars")}
+            if mars_keys.get("number", 0) == 0:
                 grib_keys["typeOfEnsembleForecast"] = 5
             else:
                 grib_keys["typeOfEnsembleForecast"] = 6
@@ -127,7 +128,8 @@ def weather_types_metadata(
         )
         grib_keys.update(out_keys)
         if grib_keys["productDefinitionTemplateNumber"] == 73:
-            if template.get("number", 0) == 0:
+            mars_keys = {k: v for k, v in template.items(namespace="mars")}
+            if mars_keys.get("number", 0) == 0:
                 grib_keys["typeOfEnsembleForecast"] = 5
             else:
                 grib_keys["typeOfEnsembleForecast"] = 6

--- a/src/pproc/schema/input.py
+++ b/src/pproc/schema/input.py
@@ -345,7 +345,6 @@ class InputSchema(BaseSchema):
             "number": lambda req: (
                 req["type"] not in ["pf", "fcmean", "fcmax", "fcstdev", "fcmin", "fc"]
             ),
-            "method": lambda req: req.get("method", None) == "ecPoint",
             "step": None,
             "fcmonth": None,
             "quantile": None,

--- a/src/pproc/schema/input.py
+++ b/src/pproc/schema/input.py
@@ -345,7 +345,7 @@ class InputSchema(BaseSchema):
             "number": lambda req: (
                 req["type"] not in ["pf", "fcmean", "fcmax", "fcstdev", "fcmin", "fc"]
             ),
-            "model": lambda req: req.get("model", None) == "ecPoint",
+            "method": lambda req: req.get("method", None) == "ecPoint",
             "step": None,
             "fcmonth": None,
             "quantile": None,

--- a/tests/config/test_types.py
+++ b/tests/config/test_types.py
@@ -1,0 +1,100 @@
+import pytest
+
+from pproc.config import types
+
+BASE_OUTPUT = {
+    "method": "ecPoint",
+    "target": "fdb",
+}
+
+
+@pytest.mark.parametrize(
+    "inputs, perc_metadata, expected",
+    [
+        [
+            [
+                {"stream": "oper", "type": "fc"},
+                {"stream": "enfo", "type": "pf", "number": [1, 2, 3]},
+            ],
+            {"stream": "enfo"},
+            [
+                {**BASE_OUTPUT, "stream": "oper", "type": "gbf"},
+                {**BASE_OUTPUT, "stream": "enfo", "type": "gbf", "number": [1, 2, 3]},
+                {**BASE_OUTPUT, "stream": "oper", "type": "gwt"},
+                {**BASE_OUTPUT, "stream": "enfo", "type": "gwt", "number": [1, 2, 3]},
+                {
+                    **BASE_OUTPUT,
+                    "stream": "enfo",
+                    "type": "pfc",
+                    "quantile": [f"{x}:{100}" for x in range(1, 101)],
+                },
+            ],
+        ],
+        [
+            [
+                {"stream": "eefo", "type": "cf"},
+                {"stream": "eefo", "type": "pf", "number": [1, 2, 3]},
+            ],
+            {},
+            [
+                {
+                    **BASE_OUTPUT,
+                    "stream": "eefo",
+                    "type": "gbf",
+                    "number": [0, 1, 2, 3],
+                },
+                {
+                    **BASE_OUTPUT,
+                    "stream": "eefo",
+                    "type": "gwt",
+                    "number": [0, 1, 2, 3],
+                },
+                {
+                    **BASE_OUTPUT,
+                    "stream": "eefo",
+                    "type": "pfc",
+                    "quantile": [f"{x}:{100}" for x in range(1, 101)],
+                },
+            ],
+        ],
+        [
+            {"stream": "oper", "type": "fc"},
+            {},
+            [
+                {**BASE_OUTPUT, "stream": "oper", "type": "gbf"},
+                {**BASE_OUTPUT, "stream": "oper", "type": "gwt"},
+                {
+                    **BASE_OUTPUT,
+                    "stream": "oper",
+                    "type": "pfc",
+                    "quantile": [f"{x}:{100}" for x in range(1, 101)],
+                },
+            ],
+        ],
+    ],
+)
+def test_ecpoint_outputs(inputs, perc_metadata, expected):
+    config = types.ECPointConfig(
+        bp_location="bp.csv",
+        fer_location="fer.csv",
+        predictant="tp",
+        predictors=[],
+        parameters={
+            "tp": {
+                "inputs": {"fc": {"request": inputs}},
+                "dependencies": {},
+                "num_inputs": 1,
+            }
+        },
+        inputs={"fc": {"source": {"type": "fdb"}}},
+        outputs={
+            "default": {"target": {"type": "fdb"}},
+            "bs": {"metadata": {"type": "gbf"}},
+            "wt": {"metadata": {"type": "gwt"}},
+            "perc": {"metadata": {"type": "pfc", **perc_metadata}},
+        },
+        quantiles=[x / 100 for x in range(1, 101)],
+    )
+    config.print()
+    outputs = list(config.out_mars(targets=["fdb"]))
+    assert outputs == expected

--- a/tests/config/test_types.py
+++ b/tests/config/test_types.py
@@ -3,7 +3,6 @@ import pytest
 from pproc.config import types
 
 BASE_OUTPUT = {
-    "method": "ecPoint",
     "target": "fdb",
 }
 


### PR DESCRIPTION
### Description
- Remove `model=ecpoint` 
- Fix derivation of `number` in ecpoint output requests to be compatible with subseasonal streams

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 