### PR TITLE
pproc-interpol: --intermediate-interpolation=

### DIFF
--- a/src/pproc/interpol.py
+++ b/src/pproc/interpol.py
@@ -150,6 +150,7 @@ def main(args=None):
         "grid",
         "interpolation",
         "interpolation_statistics",
+        "intermediate_interpolation",
         "intgrid",
         "packing",
         "accuracy",

--- a/src/pproc/interpol.py
+++ b/src/pproc/interpol.py
@@ -81,6 +81,12 @@ def main(args=None):
     )
 
     arg.add_argument(
+        "--intermediate-interpolation",
+        type=_Regex(_interpolation),
+        help="intermediate interpolation method (" + _interpolation + ")",
+    )
+
+    arg.add_argument(
         "--packing",
         type=_Regex(_packing),
         help="packing method (GRIB packingType, " + _packing + ")",
@@ -107,7 +113,7 @@ def main(args=None):
     arg.add_argument(
         "--intgrid",
         type=_Regex(_intgrid),
-        help="spectral transforms intermediate Gaussian grid (" + _intgrid + ")",
+        help="intermediate Gaussian grid (" + _intgrid + ")",
     )
 
     arg.add_argument(


### PR DESCRIPTION
### Description

Intermediate interpolation exists to support unstructured grids which have only a restricted set of available interpolation methods. This options allows to pre-interpolate to a structured grid beforehand and following with the original intended method, similar to what we already do to input spectral fields. There is a grwoing number of grids in this situation (ORCA, FESOM, ICON, YY, ...) It is intended for advanced usage.

This feature exists since mir 1.24 (2025-01). On deployment use the latest version on main/master (currently 1.27.10).




### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 