### PR TITLE
Fix setuptools-scm tag identification

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,3 +83,4 @@ write_to_template = '''# Do not change! Do not track in version control!
 __version__ = "{version}"
 '''
 local_scheme = "no-local-version"
+scm.git.describe_command = ['git', 'describe', '--dirty', '--tags', '--long', '--abbrev=40', '--match', '[0-9]*']


### PR DESCRIPTION
### Description

We use numbered tags for unstable versions, and they are picked up by setuptools-scm, giving inconsistent version numbers. This PR restricts versions to tags starting with a number.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 