### PR TITLE
Allow source request overrides to be list

### DIFF
--- a/src/pproc/config/base.py
+++ b/src/pproc/config/base.py
@@ -352,7 +352,11 @@ class BaseConfig(ConfigModel):
 
     @classmethod
     def _input_request(
-        cls, src_name: str, requests: list[dict], accum_dims: list[str], **overrides
+        cls,
+        src_name: str,
+        requests: list[dict],
+        accum_dims: list[str],
+        overrides: list | dict,
     ) -> dict | list[dict]:
         [req.pop(dim, None) for req in requests for dim in accum_dims]
         updated_inputs = [
@@ -372,7 +376,7 @@ class BaseConfig(ConfigModel):
             src_overrides = overrides.get(src_name, {}).copy()
             ret[src_name] = {
                 "request": cls._input_request(
-                    src_name, requests, accum_dims, **src_overrides.pop("request", {})
+                    src_name, requests, accum_dims, src_overrides.pop("request", {})
                 ),
                 **src_overrides,
             }

--- a/src/pproc/config/types.py
+++ b/src/pproc/config/types.py
@@ -560,12 +560,16 @@ class ProbConfig(BaseConfig):
 
     @classmethod
     def _input_request(
-        cls, src_name: str, requests: list[dict], accum_dims: list[str], **overrides
+        cls,
+        src_name: str,
+        requests: list[dict],
+        accum_dims: list[str],
+        overrides: list | dict,
     ) -> dict | list[dict]:
         if src_name == "clim":
             accum_dims = accum_dims.copy()
             accum_dims.remove("step")
-        return super()._input_request(src_name, requests, accum_dims, **overrides)
+        return super()._input_request(src_name, requests, accum_dims, overrides)
 
     @classmethod
     def sort_inputs(cls, inputs: list[dict]) -> dict:
@@ -701,12 +705,16 @@ class ExtremeConfig(BaseConfig):
 
     @classmethod
     def _input_request(
-        cls, src_name: str, requests: list[dict], accum_dims: list[str], **overrides
+        cls,
+        src_name: str,
+        requests: list[dict],
+        accum_dims: list[str],
+        overrides: list | dict,
     ) -> dict | list[dict]:
         if src_name == "clim":
             accum_dims = accum_dims.copy()
             accum_dims.remove("step")
-        return super()._input_request(src_name, requests, accum_dims, **overrides)
+        return super()._input_request(src_name, requests, accum_dims, overrides)
 
     @classmethod
     def sort_inputs(cls, inputs: list[dict]) -> dict:


### PR DESCRIPTION
### Description
Minor fix that allows the source request in overrides to be a list as well as a dict.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 