### PR TITLE
Use forkserver to create subprocesses

### DIFF
--- a/src/pproc/common/parallel.py
+++ b/src/pproc/common/parallel.py
@@ -12,6 +12,7 @@ import os
 import sys
 from typing import List
 import signal
+import multiprocessing
 
 import psutil
 from meters import ResourceMeter
@@ -47,7 +48,12 @@ class QueueingExecutor(fut.ProcessPoolExecutor):
         :queue_size: maximum number of allowed pending futures, if 0 then
         no queueing is implemented
         """
-        super().__init__(max_workers=n_par, initializer=initializer, initargs=initargs)
+        super().__init__(
+            max_workers=n_par,
+            initializer=initializer,
+            initargs=initargs,
+            mp_context=multiprocessing.get_context("forkserver"),
+        )
         self.futures = []
         self.queue_size = queue_size
 
@@ -120,7 +126,10 @@ def parallel_processing(
         SynchronousExecutor()
         if n_par == 1
         else fut.ProcessPoolExecutor(
-            max_workers=n_par, initializer=initializer, initargs=initargs
+            max_workers=n_par,
+            initializer=initializer,
+            initargs=initargs,
+            mp_context=multiprocessing.get_context("forkserver"),
         )
     )
     with executor:
@@ -172,7 +181,10 @@ def parallel_data_retrieval(
         SynchronousExecutor()
         if num_processes == 1
         else fut.ProcessPoolExecutor(
-            max_workers=num_processes, initializer=initializer, initargs=initargs
+            max_workers=num_processes,
+            initializer=initializer,
+            initargs=initargs,
+            mp_context=multiprocessing.get_context("forkserver"),
         )
     )
     with executor:

--- a/src/pproc/common/parallel.py
+++ b/src/pproc/common/parallel.py
@@ -111,7 +111,7 @@ def create_executor(
             options.queue_size,
             initializer=initializer,
             initargs=initargs,
-            mp_context=multiprocessing.get_context(mp_context),
+            mp_context=mp_context,
             **executor_kwargs,
         )
     )

--- a/src/pproc/common/parallel.py
+++ b/src/pproc/common/parallel.py
@@ -7,6 +7,7 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
+import multiprocessing
 import concurrent.futures as fut
 import os
 import sys
@@ -45,6 +46,9 @@ class QueueingExecutor(fut.ProcessPoolExecutor):
         self,
         n_par: int,
         queue_size: int = 0,
+        initializer=signal.signal,
+        initargs=(signal.SIGTERM, signal.SIG_DFL),
+        mp_context: str = "forkserver",
         **executor_kwargs,
     ):
         """
@@ -54,6 +58,9 @@ class QueueingExecutor(fut.ProcessPoolExecutor):
         """
         super().__init__(
             max_workers=n_par,
+            initializer=initializer,
+            initargs=initargs,
+            mp_context=multiprocessing.get_context(mp_context),
             **executor_kwargs,
         )
         self.futures = []
@@ -93,6 +100,7 @@ def create_executor(
     options: Parallelisation,
     initializer=signal.signal,
     initargs=(signal.SIGTERM, signal.SIG_DFL),
+    mp_context: str = "forkserver",
     **executor_kwargs,
 ) -> fut.Executor:
     return (
@@ -103,6 +111,7 @@ def create_executor(
             options.queue_size,
             initializer=initializer,
             initargs=initargs,
+            mp_context=multiprocessing.get_context(mp_context),
             **executor_kwargs,
         )
     )
@@ -114,6 +123,7 @@ def parallel_processing(
     n_par,
     initializer=signal.signal,
     initargs=(signal.SIGTERM, signal.SIG_DFL),
+    mp_context: str = "forkserver",
     **executor_kwargs,
 ):
     """Run a processing function in parallel
@@ -138,6 +148,7 @@ def parallel_processing(
             max_workers=n_par,
             initializer=initializer,
             initargs=initargs,
+            mp_context=multiprocessing.get_context(mp_context),
             **executor_kwargs,
         )
     )
@@ -172,6 +183,7 @@ def parallel_data_retrieval(
     data_requesters: List[ParamRequester],
     initializer=signal.signal,
     initargs=(signal.SIGTERM, signal.SIG_DFL),
+    mp_context: str = "forkserver",
     **executor_kwargs,
 ):
     """
@@ -194,6 +206,7 @@ def parallel_data_retrieval(
             max_workers=num_processes,
             initializer=initializer,
             initargs=initargs,
+            mp_context=multiprocessing.get_context(mp_context),
             **executor_kwargs,
         )
     )

--- a/src/pproc/common/parallel.py
+++ b/src/pproc/common/parallel.py
@@ -73,7 +73,10 @@ class QueueingExecutor(fut.ProcessPoolExecutor):
         completion, removes all complete futures and then submits
         new job
         """
-        if self.queue_size > 0 and len(self.futures) >= self.queue_size:
+        if self.queue_size == 0:
+            return super().submit(function, *args, **kwargs)
+
+        if len(self.futures) >= self.queue_size:
             print(
                 f"Queue reached max limit {self.queue_size}. Waiting for a subprocess completion"
             )
@@ -87,6 +90,7 @@ class QueueingExecutor(fut.ProcessPoolExecutor):
             self.futures[:] = new_futures
 
         self.futures.append(super().submit(function, *args, **kwargs))
+        return self.futures[-1]
 
     def wait(self):
         """

--- a/src/pproc/common/parallel.py
+++ b/src/pproc/common/parallel.py
@@ -12,7 +12,6 @@ import os
 import sys
 from typing import List
 import signal
-import multiprocessing
 
 import psutil
 from meters import ResourceMeter
@@ -42,7 +41,12 @@ class QueueingExecutor(fut.ProcessPoolExecutor):
     required for pending futures can be large.
     """
 
-    def __init__(self, n_par: int, queue_size: int = 0, initializer=None, initargs=()):
+    def __init__(
+        self,
+        n_par: int,
+        queue_size: int = 0,
+        **executor_kwargs,
+    ):
         """
         :param n_par: number of processes
         :queue_size: maximum number of allowed pending futures, if 0 then
@@ -50,9 +54,7 @@ class QueueingExecutor(fut.ProcessPoolExecutor):
         """
         super().__init__(
             max_workers=n_par,
-            initializer=initializer,
-            initargs=initargs,
-            mp_context=multiprocessing.get_context("forkserver"),
+            **executor_kwargs,
         )
         self.futures = []
         self.queue_size = queue_size
@@ -87,15 +89,21 @@ class QueueingExecutor(fut.ProcessPoolExecutor):
             future.result()
 
 
-def create_executor(options: Parallelisation) -> fut.Executor:
+def create_executor(
+    options: Parallelisation,
+    initializer=signal.signal,
+    initargs=(signal.SIGTERM, signal.SIG_DFL),
+    **executor_kwargs,
+) -> fut.Executor:
     return (
         SynchronousExecutor()
         if options.n_par_compute == 1
         else QueueingExecutor(
             options.n_par_compute,
             options.queue_size,
-            initializer=signal.signal,
-            initargs=(signal.SIGTERM, signal.SIG_DFL),
+            initializer=initializer,
+            initargs=initargs,
+            **executor_kwargs,
         )
     )
 
@@ -106,6 +114,7 @@ def parallel_processing(
     n_par,
     initializer=signal.signal,
     initargs=(signal.SIGTERM, signal.SIG_DFL),
+    **executor_kwargs,
 ):
     """Run a processing function in parallel
 
@@ -129,7 +138,7 @@ def parallel_processing(
             max_workers=n_par,
             initializer=initializer,
             initargs=initargs,
-            mp_context=multiprocessing.get_context("forkserver"),
+            **executor_kwargs,
         )
     )
     with executor:
@@ -163,6 +172,7 @@ def parallel_data_retrieval(
     data_requesters: List[ParamRequester],
     initializer=signal.signal,
     initargs=(signal.SIGTERM, signal.SIG_DFL),
+    **executor_kwargs,
 ):
     """
     Multiprocess retrieve data function from multiple data requests
@@ -184,7 +194,7 @@ def parallel_data_retrieval(
             max_workers=num_processes,
             initializer=initializer,
             initargs=initargs,
-            mp_context=multiprocessing.get_context("forkserver"),
+            **executor_kwargs,
         )
     )
     with executor:

--- a/src/pproc/config/base.py
+++ b/src/pproc/config/base.py
@@ -113,7 +113,6 @@ class BaseConfig(ConfigModel):
 
         for name in self.outputs.names:
             target = getattr(self.outputs, name).target
-            target.init()
             if (isinstance(self.parallelisation, int) and self.parallelisation > 1) or (
                 isinstance(self.parallelisation, Parallelisation)
                 and self.parallelisation.n_par_compute > 1

--- a/src/pproc/config/targets.py
+++ b/src/pproc/config/targets.py
@@ -23,7 +23,6 @@ from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, model_valida
 from pproc.config import utils
 
 _manager = None
-_opened_files = None
 
 
 def _shared_list():
@@ -31,37 +30,6 @@ def _shared_list():
     if _manager is None:
         _manager = multiprocessing.Manager()
     return _manager.list()
-
-
-def _get_opened_files():
-    global _opened_files
-    if _opened_files is None:
-        _opened_files = _shared_list()
-    return _opened_files
-
-
-def remove_duplicate(path: str, message: eccodes.Message):
-    """
-    Removes existing message in file specified by path if it has mars keys
-    matching those in message
-    """
-    if os.path.exists(path):
-        mars_keys = ",".join(
-            [f"{key}={value}" for key, value in message.items(namespace="mars")]
-        )
-        file_messages = [
-            ",".join([f"{key}={value}" for key, value in msg.items(namespace="mars")])
-            for msg in eccodes.FileReader(path)
-        ]
-        if mars_keys in file_messages:
-            print(f"Deleting duplicate message {mars_keys} in file {path}")
-            duplicate_index = file_messages.index(mars_keys)
-            with open(f"{path}.temp", "wb") as temp_file:
-                for msg_index, msg in enumerate(eccodes.FileReader(path)):
-                    if msg_index == duplicate_index:
-                        continue
-                    msg.write_to(temp_file)
-            os.rename(f"{path}.temp", path)
 
 
 class Target(BaseModel):
@@ -72,9 +40,6 @@ class Target(BaseModel):
 
     def __exit__(self, exc_type, exc_value, traceback):
         return
-
-    def init(self):
-        pass
 
     def flush(self):
         return
@@ -104,12 +69,8 @@ class FileTarget(Target):
     path: str
     clean_lock: bool = True
 
-    _mode: str = "wb"
+    _opened_files: list[str] = []
     _lock: FileLock = None
-    _overwrite_existing: bool = False
-
-    def init(self):
-        _get_opened_files()
 
     @model_validator(mode="after")
     def create_lock(self) -> Self:
@@ -119,20 +80,19 @@ class FileTarget(Target):
 
     @property
     def mode(self):
-        track_truncated = _get_opened_files()
-        if self.path not in track_truncated:
-            track_truncated.append(self.path)
-            return self._mode
+        if self.path not in self._opened_files:
+            self._opened_files.append(self.path)
+            return "wb"
         return "ab"
 
     def enable_recovery(self):
-        self._mode = "ab"
-        self._overwrite_existing = True
+        raise NotImplementedError("Recovery is not implemented for FileTarget")
+
+    def enable_parallel(self):
+        self._opened_files = _shared_list()
 
     def write(self, message):
         with self._lock:
-            if self._overwrite_existing:
-                remove_duplicate(self.path, message)
             with open(self.path, self.mode) as file:
                 message.write_to(file)
 
@@ -147,26 +107,21 @@ class FileSetTarget(Target):
     path: str
     clean_locks: bool = True
 
-    _mode: str = "wb"
     _file_locks: dict[str, FileLock] = {}
+    _opened_files: list[str] = []
     _lock_paths: list[str] = []
-    _overwrite_existing: bool = False
-
-    def init(self):
-        _get_opened_files()
 
     def mode(self, path: str):
-        track_truncated = _get_opened_files()
-        if path not in track_truncated:
-            track_truncated.append(path)
-            return self._mode
+        if path not in self._opened_files:
+            self._opened_files.append(path)
+            return "wb"
         return "ab"
 
     def enable_recovery(self):
-        self._mode = "ab"
-        self._overwrite_existing = True
+        raise NotImplementedError("Recovery is not implemented for FileSetTarget")
 
     def enable_parallel(self):
+        self._opened_files = _shared_list()
         self._lock_paths = _shared_list()
 
     def write(self, message):
@@ -174,8 +129,6 @@ class FileSetTarget(Target):
         with self._file_locks.setdefault(path, FileLock(path + ".lock")) as lock:
             if lock.lock_file not in self._lock_paths:
                 self._lock_paths.append(lock.lock_file)
-            if self._overwrite_existing:
-                remove_duplicate(path, message)
             with open(path, self.mode(path)) as file:
                 message.write_to(file)
 

--- a/src/pproc/ecpoint.py
+++ b/src/pproc/ecpoint.py
@@ -15,7 +15,6 @@ import pandas as pd
 import signal
 import logging
 import numexpr
-import concurrent.futures as fut
 
 import eccodes
 from meters import ResourceMeter
@@ -31,6 +30,7 @@ from pproc.common.steps import AnyStep
 from pproc.common.parallel import (
     parallel_data_retrieval,
     sigterm_handler,
+    QueueingExecutor,
 )
 from pproc.common.io import write_grib, GribMetadata
 from pproc.common.accumulation_manager import AccumulationManager
@@ -230,11 +230,7 @@ def compute_weather_types(
         wt_batch_size=wt_batch_size,
     )
 
-    with fut.ProcessPoolExecutor(
-        max_workers=ens_batch_size,
-        initializer=signal.signal,
-        initargs=(signal.SIGTERM, signal.SIG_DFL),
-    ) as executor:
+    with QueueingExecutor(n_par=ens_batch_size) as executor:
         for ind_em, result in enumerate(
             executor.map(ens_partial, predictant, predictors.transpose(1, 0, 2))
         ):

--- a/src/pproc/thermal_indices.py
+++ b/src/pproc/thermal_indices.py
@@ -24,7 +24,6 @@ import logging
 import sys
 import functools
 import signal
-import multiprocessing
 
 import earthkit.data
 from earthkit.data.readers.grib.metadata import GribFieldMetadata
@@ -192,9 +191,7 @@ def main():
         f"Parallel processes: {cfg.parallelisation.n_par_compute}, queue size: {cfg.parallelisation.queue_size}"
     )
 
-    with create_executor(
-        cfg.parallelisation, mp_context=multiprocessing.get_context("forkserver")
-    ) as executor:
+    with create_executor(cfg.parallelisation) as executor:
         for param in cfg.parameters:
             accum_manager = AccumulationManager.create(param.accumulations)
             checkpointed_windows = [

--- a/src/pproc/thermal_indices.py
+++ b/src/pproc/thermal_indices.py
@@ -24,6 +24,7 @@ import logging
 import sys
 import functools
 import signal
+import multiprocessing
 
 import earthkit.data
 from earthkit.data.readers.grib.metadata import GribFieldMetadata
@@ -191,7 +192,9 @@ def main():
         f"Parallel processes: {cfg.parallelisation.n_par_compute}, queue size: {cfg.parallelisation.queue_size}"
     )
 
-    with create_executor(cfg.parallelisation) as executor:
+    with create_executor(
+        cfg.parallelisation, mp_context=multiprocessing.get_context("forkserver")
+    ) as executor:
         for param in cfg.parameters:
             accum_manager = AccumulationManager.create(param.accumulations)
             checkpointed_windows = [

--- a/tests/common/test_io.py
+++ b/tests/common/test_io.py
@@ -87,7 +87,6 @@ def test_fdb_target():
 
 def test_file_target(tmpdir):
     target = io.target_from_location(f"file:{tmpdir}/test.grib")
-    target.enable_recovery()
     messages = [
         msg
         for index, msg in enumerate(eccodes.FileReader(f"{DATA_DIR}/wind.grib"))
@@ -99,28 +98,15 @@ def test_file_target(tmpdir):
     data = [msg for msg in eccodes.FileReader(f"{tmpdir}/test.grib")]
     assert len(data) == 5
 
-    # Check files are overwritten
-    for msg in messages:
-        target.write(msg)
-    data = [msg for msg in eccodes.FileReader(f"{tmpdir}/test.grib")]
-    assert len(data) == 5
-
 
 def test_fileset_target(tmpdir):
     target = io.target_from_location(f"fileset:{tmpdir}" + "/test_{step}.grib")
-    target.enable_recovery()
     for msg in eccodes.FileReader(f"{DATA_DIR}/2t_ens.grib"):
         target.write(msg)
     files = os.listdir(tmpdir)
     assert set(x for x in files if x.endswith(".grib")) == set(
         f"test_{x}.grib" for x in range(12, 37, 6)
     )
-    data = [msg for msg in eccodes.FileReader(f"{tmpdir}/test_12.grib")]
-    assert len(data) == 6
-
-    # Check files are overwritten
-    for msg in eccodes.FileReader(f"{DATA_DIR}/2t_ens.grib"):
-        target.write(msg)
     data = [msg for msg in eccodes.FileReader(f"{tmpdir}/test_12.grib")]
     assert len(data) == 6
 
@@ -150,7 +136,12 @@ def test_target_parallel(tmpdir, fdb, loc, out_loc, reqs):
     target = io.target_from_location(loc)
     target.enable_parallel()
     parallel.parallel_processing(
-        _write, [(target, x) for x in eccodes.FileReader(f"{DATA_DIR}/2t_ens.grib")], 4
+        _write,
+        [
+            (target, io.GribMetadata(x._handle))
+            for x in eccodes.FileReader(f"{DATA_DIR}/2t_ens.grib")
+        ],
+        4,
     )
 
     type_, path = loc.split(":")


### PR DESCRIPTION
### Description
- Changed default process pool to use forkserver instead of fork to resolve issues in https://jira.ecmwf.int/browse/FDB-651. As a consequence, different file type targets can no longer write to the same file without overwriting.
- Removed recovery from files.  In cases where files contain multiple fields the checking for duplicate messages is more inefficient than starting from scratch. In addition, the deduplication can fail to remove equivalent messages due to a strange eccodes bug and it is safer to restart

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 