### PR TITLE
Remove percentile computation in ecpoint

### DIFF
--- a/src/pproc/config/io.py
+++ b/src/pproc/config/io.py
@@ -277,7 +277,7 @@ WindOutputModel = create_output_model(
 )
 ThermoInputModel = create_input_model("Thermo", ["inst"], optional=["accum"])
 ThermoOutputModel = create_output_model("Thermo", ["indices", "accum", "intermediate"])
-ECPointOutputModel = create_output_model("ECPoint", ["bs", "wt", "realisations"])
+ECPointOutputModel = create_output_model("ECPoint", ["bs", "wt", "members"])
 ClusterInputModel = create_input_model(
     "Cluster", ["fc", "spread"], optional=["deterministic"]
 )

--- a/src/pproc/config/io.py
+++ b/src/pproc/config/io.py
@@ -277,7 +277,9 @@ WindOutputModel = create_output_model(
 )
 ThermoInputModel = create_input_model("Thermo", ["inst"], optional=["accum"])
 ThermoOutputModel = create_output_model("Thermo", ["indices", "accum", "intermediate"])
-ECPointOutputModel = create_output_model("ECPoint", ["bs", "wt", "members"])
+ECPointOutputModel = create_output_model(
+    "ECPoint", ["bias_corrected", "weather_types", "members"]
+)
 ClusterInputModel = create_input_model(
     "Cluster", ["fc", "spread"], optional=["deterministic"]
 )

--- a/src/pproc/config/io.py
+++ b/src/pproc/config/io.py
@@ -277,7 +277,7 @@ WindOutputModel = create_output_model(
 )
 ThermoInputModel = create_input_model("Thermo", ["inst"], optional=["accum"])
 ThermoOutputModel = create_output_model("Thermo", ["indices", "accum", "intermediate"])
-ECPointOutputModel = create_output_model("ECPoint", ["bs", "wt", "perc"])
+ECPointOutputModel = create_output_model("ECPoint", ["bs", "wt", "realisations"])
 ClusterInputModel = create_input_model(
     "Cluster", ["fc", "spread"], optional=["deterministic"]
 )

--- a/src/pproc/config/types.py
+++ b/src/pproc/config/types.py
@@ -1002,8 +1002,8 @@ class ECPointParamConfig(ParamConfig):
 
 class ECPointParallelisation(BaseModel):
     n_par_read: int = 1
+    n_par_compute: int = 1
     wt_batch_size: int = 1
-    ens_batch_size: int = 1
 
 
 class ECPointConfig(BaseConfig):

--- a/src/pproc/config/types.py
+++ b/src/pproc/config/types.py
@@ -1006,7 +1006,7 @@ class ECPointParallelisation(BaseModel):
     ens_batch_size: int = 1
 
 
-class ECPointConfig(QuantilesConfig):
+class ECPointConfig(BaseConfig):
     parallelisation: ECPointParallelisation = ECPointParallelisation()
     outputs: io.ECPointOutputModel = io.ECPointOutputModel()
     parameters: list[ECPointParamConfig]
@@ -1093,10 +1093,6 @@ class ECPointConfig(QuantilesConfig):
 
     def _format_out(self, param: ParamConfig, req) -> dict:
         req = super()._format_out(param, req)
-        if req["type"] == "pfc":
-            return req
-
-        req.pop("quantile")
         self._append_number(param, req)
         return req
 

--- a/src/pproc/ecpoint.py
+++ b/src/pproc/ecpoint.py
@@ -261,8 +261,8 @@ def ecpoint_iteration(
         )
 
     with ResourceMeter(f"Compute members on ecpoint: {window_id}"):
-        out_bs = config.outputs.bs
-        out_wt = config.outputs.wt
+        out_bc = config.outputs.bias_corrected
+        out_wt = config.outputs.weather_types
         out_members = config.outputs.members
 
         for index, (
@@ -291,10 +291,10 @@ def ecpoint_iteration(
                 template,
                 {
                     **out_keys,
-                    **out_bs.metadata,
+                    **out_bc.metadata,
                 },
             )
-            write_grib(out_bs.target, bs_message, grid_bc_allwt, metadata)
+            write_grib(out_bc.target, bs_message, grid_bc_allwt, metadata)
 
             wt_message, metadata = weather_types_metadata(
                 template, {**out_keys, **out_wt.metadata}
@@ -316,7 +316,7 @@ def ecpoint_iteration(
                     metadata,
                 )
 
-    out_bs.target.flush()
+    out_bc.target.flush()
     out_wt.target.flush()
     out_members.target.flush()
     config.recovery.add_checkpoint(param=param.name, window=window_id)

--- a/src/pproc/ecpoint.py
+++ b/src/pproc/ecpoint.py
@@ -71,7 +71,6 @@ def grid_bc_metadata(template: CodesHandle, out_keys: dict) -> tuple[CodesHandle
                 "edition": 2,
                 "productDefinitionTemplateNumber": 73,
                 "type": "gbf",
-                "inputProcessIdentifier": template.get("generatingProcessIdentifier"),
                 "inputOriginatingCentre": template.get("originatingCentre"),
                 "typeOfGeneratingProcess": 13,
                 "typeOfPostProcessing": 206,
@@ -110,10 +109,37 @@ def weather_types_metadata(
                 "productDefinitionTemplateNumber": 73,
                 "type": "gwt",
                 "packingType": "grid_ieee",
-                "inputProcessIdentifier": template.get("generatingProcessIdentifier"),
                 "inputOriginatingCentre": template.get("originatingCentre"),
                 "typeOfGeneratingProcess": 13,
                 "typeOfPostProcessing": 206,
+                "indicatorOfUnitForTimeIncrement": 1,
+                "timeIncrement": 1,
+            }
+        )
+        grib_keys.update(out_keys)
+        if grib_keys["productDefinitionTemplateNumber"] == 73:
+            mars_keys = {k: v for k, v in template.items(namespace="mars")}
+            if mars_keys.get("number", 0) == 0:
+                grib_keys["typeOfEnsembleForecast"] = 5
+            else:
+                grib_keys["typeOfEnsembleForecast"] = 6
+    else:
+        grib_keys.update(out_keys)
+    return template, grib_keys
+
+
+def realisations_metadata(template: CodesHandle, out_keys: dict) -> dict:
+    edition = out_keys.get("edition", template.get("edition"))
+    if edition not in (1, 2):
+        raise ValueError(f"Unsupported GRIB edition {edition}")
+
+    grib_keys = {}
+    if edition == 2:
+        grib_keys.update(
+            {
+                "edition": 2,
+                "productDefinitionTemplateNumber": 73,
+                "inputOriginatingCentre": template.get("originatingCentre"),
                 "indicatorOfUnitForTimeIncrement": 1,
                 "timeIncrement": 1,
             }
@@ -276,11 +302,18 @@ def ecpoint_iteration(
             write_grib(out_wt.target, wt_message, wt_allwt, metadata)
 
             for number in range(len(pt_bc_allwt)):
+                msg, metadata = realisations_metadata(
+                    template,
+                    {
+                        **out_keys,
+                        **out_realisations.metadata,
+                    },
+                )
                 write_grib(
                     out_realisations.target,
-                    template,
+                    msg,
                     pt_bc_allwt[number],
-                    {**out_keys, **out_realisations.metadata},
+                    metadata,
                 )
 
     out_bs.target.flush()

--- a/src/pproc/ecpoint.py
+++ b/src/pproc/ecpoint.py
@@ -18,7 +18,6 @@ import numexpr
 
 import eccodes
 from meters import ResourceMeter
-from earthkit.meteo.stats import iter_quantiles
 from conflator import Conflator
 import earthkit.data
 from earthkit.data.utils.message import CodesHandle
@@ -34,7 +33,6 @@ from pproc.common.parallel import (
 )
 from pproc.common.io import write_grib, GribMetadata
 from pproc.common.accumulation_manager import AccumulationManager
-from pproc.quantile.grib import quantiles_metadata
 from pproc.ecpt.predictors import compute_predictors
 
 logger = logging.getLogger(__name__)
@@ -130,33 +128,6 @@ def weather_types_metadata(
     else:
         grib_keys.update(out_keys)
     return template, grib_keys
-
-
-def point_scale_metadata(
-    template: CodesHandle, pert_number: int, total_number: int, out_keys: dict
-) -> dict:
-    edition = out_keys.get("edition", template.get("edition"))
-    if edition not in (1, 2):
-        raise ValueError(f"Unsupported GRIB edition {edition}")
-
-    grib_keys = {}
-    if edition == 2:
-        grib_keys.update(
-            {
-                "edition": 2,
-                "productDefinitionTemplateNumber": 90,
-                "type": "pfc",
-                "inputProcessIdentifier": template.get("generatingProcessIdentifier"),
-                "inputOriginatingCentre": template.get("originatingCentre"),
-                "typeOfGeneratingProcess": 13,
-                "typeOfPostProcessing": 206,
-                "indicatorOfUnitForTimeIncrement": 1,
-                "timeIncrement": 1,
-            }
-        )
-    grib_keys.update(out_keys)
-    return quantiles_metadata(template, pert_number, total_number, grib_keys)
-
 
 def compute_single_ens(
     predictant: np.ndarray,
@@ -262,10 +233,10 @@ def ecpoint_iteration(
             config, param, out_keys["stepRange"], input_params
         )
 
-    pt_bc_allens_allwt = []
     with ResourceMeter(f"Compute realisations: {window_id}"):
         out_bs = config.outputs.bs
         out_wt = config.outputs.wt
+        out_realisations = config.outputs.realisations
 
         for index, (
             pt_bc_allwt,
@@ -302,28 +273,18 @@ def ecpoint_iteration(
                 template, {**out_keys, **out_wt.metadata}
             )
             write_grib(out_wt.target, wt_message, wt_allwt, metadata)
-            pt_bc_allens_allwt.append(pt_bc_allwt)
-        pt_bc_allens_allwt = np.concatenate(pt_bc_allens_allwt)
 
-    with ResourceMeter(f"Compute percentiles: {window_id}"):
-        out_perc = config.outputs.perc
-        template = predictant[0].metadata()._handle
-        for i, quantile in enumerate(
-            iter_quantiles(pt_bc_allens_allwt, config.quantiles, method="sort")
-        ):
-            grib_keys = {
-                **out_keys,
-                **out_perc.metadata,
-            }
-            pert_number, total_number = config.quantile_indices(i)
-            metadata = point_scale_metadata(
-                template, pert_number, total_number, grib_keys
-            )
-            write_grib(out_perc.target, template, quantile, metadata)
+            for number in range(len(pt_bc_allwt)):
+                write_grib(
+                    out_realisations.target,
+                    template,
+                    pt_bc_allwt[number],
+                    out_keys,
+                )
 
     out_bs.target.flush()
     out_wt.target.flush()
-    out_perc.target.flush()
+    out_realisations.target.flush()
     config.recovery.add_checkpoint(param=param.name, window=window_id)
 
 

--- a/src/pproc/ecpoint.py
+++ b/src/pproc/ecpoint.py
@@ -128,7 +128,7 @@ def weather_types_metadata(
     return template, grib_keys
 
 
-def realisations_metadata(template: CodesHandle, out_keys: dict) -> dict:
+def members_metadata(template: CodesHandle, out_keys: dict) -> dict:
     edition = out_keys.get("edition", template.get("edition"))
     if edition not in (1, 2):
         raise ValueError(f"Unsupported GRIB edition {edition}")
@@ -260,10 +260,10 @@ def ecpoint_iteration(
             config, param, out_keys["stepRange"], input_params
         )
 
-    with ResourceMeter(f"Compute realisations: {window_id}"):
+    with ResourceMeter(f"Compute members on ecpoint: {window_id}"):
         out_bs = config.outputs.bs
         out_wt = config.outputs.wt
-        out_realisations = config.outputs.realisations
+        out_members = config.outputs.members
 
         for index, (
             pt_bc_allwt,
@@ -302,15 +302,15 @@ def ecpoint_iteration(
             write_grib(out_wt.target, wt_message, wt_allwt, metadata)
 
             for number in range(len(pt_bc_allwt)):
-                msg, metadata = realisations_metadata(
+                msg, metadata = members_metadata(
                     template,
                     {
                         **out_keys,
-                        **out_realisations.metadata,
+                        **out_members.metadata,
                     },
                 )
                 write_grib(
-                    out_realisations.target,
+                    out_members.target,
                     msg,
                     pt_bc_allwt[number],
                     metadata,
@@ -318,7 +318,7 @@ def ecpoint_iteration(
 
     out_bs.target.flush()
     out_wt.target.flush()
-    out_realisations.target.flush()
+    out_members.target.flush()
     config.recovery.add_checkpoint(param=param.name, window=window_id)
 
 

--- a/src/pproc/ecpoint.py
+++ b/src/pproc/ecpoint.py
@@ -206,7 +206,7 @@ def compute_weather_types(
     fer_loc: str,
     min_predictant: Optional[float] = None,
     wt_batch_size: int = 1,
-    ens_batch_size: int = 1,
+    n_par: int = 1,
 ) -> Iterator[Tuple[np.ndarray, np.ndarray, np.ndarray]]:
     # Extract variables from files
     bp_file = pd.read_csv(bp_loc, header=0, delimiter=",")
@@ -228,7 +228,7 @@ def compute_weather_types(
         wt_batch_size=wt_batch_size,
     )
 
-    with QueueingExecutor(n_par=ens_batch_size) as executor:
+    with QueueingExecutor(n_par=n_par) as executor:
         for ind_em, result in enumerate(
             executor.map(ens_partial, predictant, predictors.transpose(1, 0, 2))
         ):
@@ -277,7 +277,7 @@ def ecpoint_iteration(
                 config.fer_location,
                 config.min_predictant,
                 config.parallelisation.wt_batch_size,
-                config.parallelisation.ens_batch_size,
+                config.parallelisation.n_par_compute,
             )
         ):
 

--- a/src/pproc/ecpoint.py
+++ b/src/pproc/ecpoint.py
@@ -129,6 +129,7 @@ def weather_types_metadata(
         grib_keys.update(out_keys)
     return template, grib_keys
 
+
 def compute_single_ens(
     predictant: np.ndarray,
     predictors: np.ndarray,
@@ -279,7 +280,7 @@ def ecpoint_iteration(
                     out_realisations.target,
                     template,
                     pt_bc_allwt[number],
-                    out_keys,
+                    {**out_keys, **out_realisations.metadata},
                 )
 
     out_bs.target.flush()

--- a/src/pproc/schema/input.py
+++ b/src/pproc/schema/input.py
@@ -343,7 +343,8 @@ class InputSchema(BaseSchema):
         out = copy.deepcopy(request)
         ignore_inheritance = {
             "number": lambda req: (
-                req["type"] not in ["pf", "fcmean", "fcmax", "fcstdev", "fcmin", "fc"]
+                req["type"]
+                not in ["pf", "fcmean", "fcmax", "fcstdev", "fcmin", "fc", "gwt"]
             ),
             "step": None,
             "fcmonth": None,
@@ -420,9 +421,9 @@ class InputSchema(BaseSchema):
             output_request["number"] = sum(
                 [to_list(req.get("number", [0])) for req in input_requests], []
             )
-        elif tp == "pf":
+        elif tp in ["pf", "gwt"]:
             for req in input_requests:
-                if req["type"] == "pf":
+                if req["type"] in ["pf", "gwt"] and "number" in req:
                     output_request["number"] = req["number"]
                     break
         elif tp in ["pb", "cd"]:

--- a/tests/config/types/test_ecpoint.py
+++ b/tests/config/types/test_ecpoint.py
@@ -69,7 +69,7 @@ def test_ecpoint_outputs(inputs, expected):
             "default": {"target": {"type": "fdb"}},
             "bs": {"metadata": {"type": "gbf"}},
             "wt": {"metadata": {"type": "gwt"}},
-            "realisations": {"target": {"type": "file", "path": "realisations.grib"}},
+            "members": {"target": {"type": "file", "path": "members.grib"}},
         },
     )
     config.print()

--- a/tests/config/types/test_ecpoint.py
+++ b/tests/config/types/test_ecpoint.py
@@ -67,8 +67,8 @@ def test_ecpoint_outputs(inputs, expected):
         inputs={"fc": {"source": {"type": "fdb"}}},
         outputs={
             "default": {"target": {"type": "fdb"}},
-            "bs": {"metadata": {"type": "gbf"}},
-            "wt": {"metadata": {"type": "gwt"}},
+            "bias_corrected": {"metadata": {"type": "gbf"}},
+            "weather_types": {"metadata": {"type": "gwt"}},
             "members": {"target": {"type": "file", "path": "members.grib"}},
         },
     )

--- a/tests/config/types/test_ecpoint.py
+++ b/tests/config/types/test_ecpoint.py
@@ -8,25 +8,18 @@ BASE_OUTPUT = {
 
 
 @pytest.mark.parametrize(
-    "inputs, perc_metadata, expected",
+    "inputs, expected",
     [
         [
             [
                 {"stream": "oper", "type": "fc"},
                 {"stream": "enfo", "type": "pf", "number": [1, 2, 3]},
             ],
-            {"stream": "enfo"},
             [
                 {**BASE_OUTPUT, "stream": "oper", "type": "gbf"},
                 {**BASE_OUTPUT, "stream": "enfo", "type": "gbf", "number": [1, 2, 3]},
                 {**BASE_OUTPUT, "stream": "oper", "type": "gwt"},
                 {**BASE_OUTPUT, "stream": "enfo", "type": "gwt", "number": [1, 2, 3]},
-                {
-                    **BASE_OUTPUT,
-                    "stream": "enfo",
-                    "type": "pfc",
-                    "quantile": [f"{x}:{100}" for x in range(1, 101)],
-                },
             ],
         ],
         [
@@ -34,7 +27,6 @@ BASE_OUTPUT = {
                 {"stream": "eefo", "type": "cf"},
                 {"stream": "eefo", "type": "pf", "number": [1, 2, 3]},
             ],
-            {},
             [
                 {
                     **BASE_OUTPUT,
@@ -48,31 +40,18 @@ BASE_OUTPUT = {
                     "type": "gwt",
                     "number": [0, 1, 2, 3],
                 },
-                {
-                    **BASE_OUTPUT,
-                    "stream": "eefo",
-                    "type": "pfc",
-                    "quantile": [f"{x}:{100}" for x in range(1, 101)],
-                },
             ],
         ],
         [
             {"stream": "oper", "type": "fc"},
-            {},
             [
                 {**BASE_OUTPUT, "stream": "oper", "type": "gbf"},
                 {**BASE_OUTPUT, "stream": "oper", "type": "gwt"},
-                {
-                    **BASE_OUTPUT,
-                    "stream": "oper",
-                    "type": "pfc",
-                    "quantile": [f"{x}:{100}" for x in range(1, 101)],
-                },
             ],
         ],
     ],
 )
-def test_ecpoint_outputs(inputs, perc_metadata, expected):
+def test_ecpoint_outputs(inputs, expected):
     config = types.ECPointConfig(
         bp_location="bp.csv",
         fer_location="fer.csv",
@@ -90,9 +69,8 @@ def test_ecpoint_outputs(inputs, perc_metadata, expected):
             "default": {"target": {"type": "fdb"}},
             "bs": {"metadata": {"type": "gbf"}},
             "wt": {"metadata": {"type": "gwt"}},
-            "perc": {"metadata": {"type": "pfc", **perc_metadata}},
+            "realisations": {"target": {"type": "file", "path": "realisations.grib"}},
         },
-        quantiles=[x / 100 for x in range(1, 101)],
     )
     config.print()
     outputs = list(config.out_mars(targets=["fdb"]))


### PR DESCRIPTION
### Description
Change ecpoint entrypoint to output ensemble members on ecpoint instead of percentiles, allowing for splitting across members. This is required to handle larger decision trees with more weather types. 

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 