### PR TITLE
Fix MARS retrieval with vod2uv

### DIFF
--- a/src/pproc/common/dataset.py
+++ b/src/pproc/common/dataset.py
@@ -12,11 +12,19 @@ import pprint
 from contextlib import ExitStack
 from io import BytesIO
 from typing import Any, Callable, Iterable, Iterator, List, Optional, Union
+import os
 
 import eccodes
 import mir
 
-from pproc.common.io import FileTarget, NullTarget, fdb, fdb_retrieve, split_location
+from pproc.common.io import (
+    FileTarget,
+    NullTarget,
+    fdb,
+    fdb_retrieve,
+    split_location,
+    mir_wind_input,
+)
 from pproc.common.mars import mars_retrieve
 
 
@@ -91,15 +99,19 @@ def _mars_retrieve_interp(
     )
     mars_reader = mars_retrieve(request, mars_cmd=mars_cmd, tmpdir=tmpdir)
     if mir_options:
+        cached_file = None
         with mars_reader:
             if mir_options.get("vod2uv", False):
                 mir_options = mir_options.copy()
                 mir_options["vod2uv"] = "1"
+                mars_reader, cached_file = mir_wind_input(mars_reader, request)
             job = mir.Job(**mir_options)
             stream = BytesIO()
             job.execute(mars_reader, stream)
         stream.seek(0)
         mars_reader = stream
+        if cached_file:
+            os.remove(cached_file)
     return MARSDecoder(mars_reader, cache=cache)
 
 

--- a/src/pproc/common/io.py
+++ b/src/pproc/common/io.py
@@ -184,6 +184,7 @@ def mir_wind_input(fdb_reader, request, cached_file=None):
             + ".grb"
         )
     fields = earthkit.data.from_source("stream", fdb_reader, read_all=True)
+    # Mir expects vo and d fields to be paired, so param must be last in order
     fields = fields.order_by([x for x in list_keys if x != "param"])
     fields.to_target("file", cached_file)
     if os.path.getsize(cached_file) == 0:

--- a/src/pproc/common/io.py
+++ b/src/pproc/common/io.py
@@ -20,6 +20,7 @@ import yaml
 import eccodes
 import pyfdb
 import mir
+import earthkit.data
 from earthkit.data.readers.grib.metadata import StandAloneGribMetadata
 from earthkit.data.readers.grib.codes import GribCodesHandle
 
@@ -171,23 +172,20 @@ def read_grib_messages(messages, dims=()):
 
 
 def mir_wind_input(fdb_reader, request, cached_file=None):
+    list_keys = [key for key in request if isinstance(request[key], (list, range))]
     if not cached_file:
         cached_file = (
             "_".join(
                 [
-                    (
-                        f"{key}{len(value)}"
-                        if isinstance(value, (list, range))
-                        else f"{key}{value}"
-                    )
+                    (f"{key}{len(value)}" if key in list_keys else f"{key}{value}")
                     for key, value in request.items()
                 ]
             )
             + ".grb"
         )
-    outfile = open(cached_file, "wb")
-    for data in iter((lambda: fdb_reader.read(4096)), b""):
-        outfile.write(data)
+    fields = earthkit.data.from_source("stream", fdb_reader, read_all=True)
+    fields = fields.order_by([x for x in list_keys if x != "param"])
+    fields.to_target("file", cached_file)
     if os.path.getsize(cached_file) == 0:
         raise RuntimeError(f"No data retrieved for request {request}")
     return mir.MultiDimensionalGribFileInput(cached_file, 2), cached_file

--- a/src/pproc/config/param.py
+++ b/src/pproc/config/param.py
@@ -173,11 +173,13 @@ class ParamConfig(BaseModel):
         fc_name = inputs.names[0]
         base_input: Input = getattr(inputs, fc_name)
         param_input = self.inputs.get(fc_name, {})
+        vod2uv_param = {"param": [131, 132]} if self.vod2uv else {}
         reqs = update_request(
             base_input.request,
             param_input.get("request", {}),
             **{
                 **inputs.overrides,
+                **vod2uv_param,
                 **extract_mars(metadata or {}),
                 **extract_mars(self.metadata),
             },

--- a/tests/config/test_param.py
+++ b/tests/config/test_param.py
@@ -11,6 +11,7 @@ import pytest
 
 from pproc.config.param import ParamConfig
 from pproc.config.io import BaseInputModel
+from pproc.config.utils import extract_mars
 
 base_config = {
     "name": "2t",
@@ -117,3 +118,85 @@ def test_totalfields(config, expected):
     inputs = BaseInputModel(fc={"source": {"type": "fdb"}})
     param.validate_totalfields(inputs)
     assert param.total_fields == expected
+
+
+@pytest.mark.parametrize(
+    "config, expected",
+    [
+        [
+            {
+                "inputs": {
+                    "fc": {
+                        "request": {
+                            "levelist": [1, 2],
+                            "param": [138, 155],
+                        }
+                    }
+                },
+                "accumulations": {
+                    "step": {"operation": "mean", "coords": [[0, 6, 12]]},
+                },
+            },
+            [
+                {
+                    "param": [138, 155],
+                    "levelist": [1, 2],
+                    "step": ["0-12"],
+                }
+            ],
+        ],
+        [
+            {
+                "inputs": {
+                    "fc": {
+                        "request": {
+                            "levelist": [1, 2],
+                            "param": [138, 155],
+                            "interpolate": {"vod2uv": True},
+                        }
+                    }
+                },
+                "accumulations": {
+                    "step": {"operation": "mean", "coords": [[0, 6, 12]]},
+                },
+            },
+            [
+                {
+                    "param": [131, 132],
+                    "levelist": [1, 2],
+                    "step": ["0-12"],
+                }
+            ],
+        ],
+        [
+            {
+                "inputs": {
+                    "fc": {
+                        "request": {
+                            "levelist": [1, 2],
+                            "param": [138, 155],
+                            "interpolate": {"vod2uv": True},
+                        }
+                    }
+                },
+                "accumulations": {
+                    "step": {"operation": "mean", "coords": [[0, 6, 12]]},
+                },
+                "metadata": {"paramId": 10},
+            },
+            [
+                {
+                    "param": 10,
+                    "levelist": [1, 2],
+                    "step": ["0-12"],
+                }
+            ],
+        ],
+    ],
+    ids=["no-vod2uv", "vod2uv", "vod2uv-with-metadata"],
+)
+def test_vod2uv(config, expected):
+    param = ParamConfig(**{**base_config, **config})
+    inputs = BaseInputModel(fc={"source": {"type": "fdb"}})
+    out_keys = [extract_mars(x) for x in param.out_keys(inputs)]
+    assert out_keys == expected


### PR DESCRIPTION
### Description
- Add generation of mir wind input file for MARS retrievals
- Change mir_wind_input to use earthkit.data to reorder inputs to ensure vo, d are in pairs
- Fix output request when computing u/v from vo/d and add tests

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 