### PR TITLE
feat: add entrypoint for cape and cin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ pproc-monthly-stats = "pproc.monthly_stats:main"
 pproc-config="pproc.config_generation:main"
 pproc-ecpoint = "pproc.ecpoint:main"
 pproc-flight-levels = "pproc.flight_levels:main"
+pproc-cape = "pproc.cape_cin:main"
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/src/pproc/cape/__init__.py
+++ b/src/pproc/cape/__init__.py
@@ -1,0 +1,8 @@
+# (C) Copyright 2026- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.

--- a/src/pproc/cape/compute.py
+++ b/src/pproc/cape/compute.py
@@ -1,0 +1,123 @@
+# (C) Copyright 2021- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Compute MUCAPE and MUCIN from pressure-level and surface data.
+
+Wraps :func:`earthkit.meteo.thermo.cape_cin` (parcel_type="mu").
+Until the function is available in earthkit-meteo, a dummy
+implementation is used for testing.
+"""
+
+from typing import Tuple
+
+import numpy as np
+from numpy.typing import ArrayLike
+
+
+def _dummy_cape_cin(
+    p: ArrayLike,
+    zh: ArrayLike,
+    t: ArrayLike,
+    q: ArrayLike,
+    p_sfc: ArrayLike,
+    zh_sfc: ArrayLike,
+    t_sfc: ArrayLike,
+    q_sfc: ArrayLike,
+    parcel_type: str,
+    layer_depth: float | None = None,
+    extra_outputs: list | None = None,
+    vertical_axis: int = 0,
+    ept_method: str = "bolton43",
+    lcl_method: str = "davies",
+) -> Tuple[ArrayLike, ArrayLike]:
+    """Dummy cape_cin returning zero arrays.  Used for testing until
+    :func:`earthkit.meteo.thermo.cape_cin` is released."""
+    horiz_shape = p.shape[1:] if vertical_axis == 0 else p.shape[:-1]
+    cape = np.zeros(horiz_shape, dtype=np.float64)
+    cin = np.zeros(horiz_shape, dtype=np.float64)
+    return cape, cin
+
+
+def _get_cape_cin_func():
+    """Return the real cape_cin if available, else the dummy."""
+    try:
+        from earthkit.meteo.thermo import cape_cin
+        return cape_cin
+    except ImportError:
+        return _dummy_cape_cin
+
+
+def compute_mucape_mucin(
+    t: ArrayLike,
+    q: ArrayLike,
+    zh: ArrayLike,
+    p_levels_hpa: list[int],
+    t_sfc: ArrayLike,
+    q_sfc: ArrayLike,
+    zh_sfc: ArrayLike,
+    p_sfc: ArrayLike,
+) -> Tuple[ArrayLike, ArrayLike]:
+    """Compute most-unstable CAPE and CIN on pressure levels.
+
+    Parameters
+    ----------
+    t : array-like
+        Temperature on pressure levels (K), shape ``(n_levels, n_points)``.
+        Levels must be ordered by ascending pressure (TOA first).
+    q : array-like
+        Specific humidity on pressure levels (kg/kg), same shape as ``t``.
+    zh : array-like
+        Geopotential height on pressure levels (m), same shape as ``t``.
+    p_levels_hpa : list of int
+        Pressure levels in hPa, ascending order (e.g. [50, 100, …, 1000]).
+    t_sfc : array-like
+        Surface temperature (K), shape ``(n_points,)``.
+    q_sfc : array-like
+        Surface specific humidity (kg/kg), shape ``(n_points,)``.
+    zh_sfc : array-like
+        Surface geopotential height (m), shape ``(n_points,)``.
+    p_sfc : array-like
+        Surface pressure (Pa), shape ``(n_points,)``.
+
+    Returns
+    -------
+    mucape : array-like
+        Most-unstable CAPE (J/kg), shape ``(n_points,)``.
+    mucin : array-like
+        Most-unstable CIN (J/kg), shape ``(n_points,)``.
+    """
+    t = np.asarray(t, dtype=np.float64)
+    q = np.asarray(q, dtype=np.float64)
+    zh = np.asarray(zh, dtype=np.float64)
+    t_sfc = np.asarray(t_sfc, dtype=np.float64)
+    q_sfc = np.asarray(q_sfc, dtype=np.float64)
+    zh_sfc = np.asarray(zh_sfc, dtype=np.float64)
+    p_sfc = np.asarray(p_sfc, dtype=np.float64)
+
+    n_levels = t.shape[0]
+    n_points = t.shape[1] if t.ndim > 1 else 1
+
+    # Build pressure array: broadcast level list (hPa → Pa) to field shape
+    p_pa = np.array(p_levels_hpa, dtype=np.float64) * 100.0
+    p = np.broadcast_to(p_pa[:, np.newaxis], (n_levels, n_points))
+
+    cape_cin_func = _get_cape_cin_func()
+    mucape, mucin = cape_cin_func(
+        p=p,
+        zh=zh,
+        t=t,
+        q=q,
+        p_sfc=p_sfc,
+        zh_sfc=zh_sfc,
+        t_sfc=t_sfc,
+        q_sfc=q_sfc,
+        parcel_type="mu",
+        vertical_axis=0,
+    )
+    return mucape, mucin

--- a/src/pproc/cape/compute.py
+++ b/src/pproc/cape/compute.py
@@ -7,11 +7,12 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-"""Compute MUCAPE and MUCIN from pressure-level and surface data.
+"""Compute CAPE and CIN from pressure-level and surface data.
 
-Wraps :func:`earthkit.meteo.thermo.cape_cin` (parcel_type="mu").
-Until the function is available in earthkit-meteo, a dummy
-implementation is used for testing.
+Wraps :func:`earthkit.meteo.thermo.cape_cin` with configurable
+parcel type (``"mu"`` for most-unstable, ``"ml"`` for mixed-layer)
+and optional layer depth.  Until the function is available in
+earthkit-meteo, a dummy implementation is used for testing.
 """
 
 from typing import Tuple
@@ -53,7 +54,7 @@ def _get_cape_cin_func():
         return _dummy_cape_cin
 
 
-def compute_mucape_mucin(
+def compute_cape_cin(
     t: ArrayLike,
     q: ArrayLike,
     zh: ArrayLike,
@@ -62,8 +63,10 @@ def compute_mucape_mucin(
     q_sfc: ArrayLike,
     zh_sfc: ArrayLike,
     p_sfc: ArrayLike,
+    parcel_type: str = "mu",
+    layer_depth: float | None = None,
 ) -> Tuple[ArrayLike, ArrayLike]:
-    """Compute most-unstable CAPE and CIN on pressure levels.
+    """Compute CAPE and CIN on pressure levels.
 
     Parameters
     ----------
@@ -84,13 +87,20 @@ def compute_mucape_mucin(
         Surface geopotential height (m), shape ``(n_points,)``.
     p_sfc : array-like
         Surface pressure (Pa), shape ``(n_points,)``.
+    parcel_type : str
+        Parcel type for the CAPE/CIN computation.  ``"mu"`` for
+        most-unstable, ``"mixed"`` for mixed-layer, ``"surface"``
+        for surface parcel.
+    layer_depth : float or None
+        Depth of the layer in Pa (e.g. 5000.0 for 50 hPa).
+        Used by ``"mixed"`` and ``"mu"`` parcel types.
 
     Returns
     -------
-    mucape : array-like
-        Most-unstable CAPE (J/kg), shape ``(n_points,)``.
-    mucin : array-like
-        Most-unstable CIN (J/kg), shape ``(n_points,)``.
+    cape : array-like
+        CAPE (J/kg), shape ``(n_points,)``.
+    cin : array-like
+        CIN (J/kg), shape ``(n_points,)``.
     """
     t = np.asarray(t, dtype=np.float64)
     q = np.asarray(q, dtype=np.float64)
@@ -108,7 +118,8 @@ def compute_mucape_mucin(
     p = np.broadcast_to(p_pa[:, np.newaxis], (n_levels, n_points))
 
     cape_cin_func = _get_cape_cin_func()
-    mucape, mucin = cape_cin_func(
+
+    kwargs = dict(
         p=p,
         zh=zh,
         t=t,
@@ -117,7 +128,11 @@ def compute_mucape_mucin(
         zh_sfc=zh_sfc,
         t_sfc=t_sfc,
         q_sfc=q_sfc,
-        parcel_type="mu",
+        parcel_type=parcel_type,
         vertical_axis=0,
     )
-    return mucape, mucin
+    if layer_depth is not None:
+        kwargs["layer_depth"] = layer_depth
+
+    cape, cin = cape_cin_func(**kwargs)
+    return cape, cin

--- a/src/pproc/cape_cin.py
+++ b/src/pproc/cape_cin.py
@@ -21,7 +21,7 @@ from meters import ResourceMeter
 from earthkit.meteo import constants
 from earthkit.meteo.thermo import specific_humidity_from_dewpoint
 
-from pproc.cape.compute import compute_mucape_mucin
+from pproc.cape.compute import compute_cape_cin
 from pproc.common.accumulation_manager import AccumulationManager
 from pproc.common.io import write_grib
 from pproc.common.parallel import parallel_processing, sigterm_handler
@@ -32,17 +32,13 @@ from pproc.config.types import CapeConfig
 
 logger = logging.getLogger(__name__)
 
-# GRIB paramId for MUCAPE and MUCIN
-MUCAPE_PARAM_ID = 228235
-MUCIN_PARAM_ID = 228236
-
 
 def cape_iteration(
     config: CapeConfig,
     pconfig: ParamConfig,
     dims: dict,
 ) -> None:
-    """Process one (step, …) slice: retrieve data, compute MUCAPE/MUCIN, write output."""
+    """Process one (step, …) slice: retrieve data, compute CAPE/CIN, write output."""
     ids = ", ".join(f"{k}={v}" for k, v in dims.items())
 
     fields = SimpleFieldList()
@@ -87,7 +83,6 @@ def cape_iteration(
             zh_sfc_vals = z_sfc_vals / constants.g  # m
             q_sfc_vals = specific_humidity_from_dewpoint(td_sfc_vals, p_sfc_vals)
 
-
             # PL arrays
             n_points = p_sfc_vals.shape[0]
             n_levels = len(levels_sorted)
@@ -105,49 +100,49 @@ def cape_iteration(
                 q_arr[lev_idx] = q_field[member].values
                 zh_arr[lev_idx] = z_field[member].values / constants.g  # geopotential → height
 
-            # Compute MUCAPE / MUCIN
-            mucape, mucin = compute_mucape_mucin(
-                t=t_arr,
-                q=q_arr,
-                zh=zh_arr,
-                p_levels_hpa=levels_sorted,
-                t_sfc=t_sfc_vals,
-                q_sfc=q_sfc_vals,
-                zh_sfc=zh_sfc_vals,
-                p_sfc=p_sfc_vals,
-            )
-
-            # Write GRIB output
+            # Compute and write all configured CAPE/CIN products
             template = sfc_template._handle
+            for product in config.cape_products:
+                cape, cin = compute_cape_cin(
+                    t=t_arr,
+                    q=q_arr,
+                    zh=zh_arr,
+                    p_levels_hpa=levels_sorted,
+                    t_sfc=t_sfc_vals,
+                    q_sfc=q_sfc_vals,
+                    zh_sfc=zh_sfc_vals,
+                    p_sfc=p_sfc_vals,
+                    parcel_type=product.parcel_type,
+                    layer_depth=product.layer_depth,
+                )
 
-            out_mucape = config.outputs.mucape
-            write_grib(
-                out_mucape.target,
-                template,
-                mucape.astype(np.float32),
-                {
-                    **out_mucape.metadata,
-                    **pconfig.metadata,
-                    "paramId": MUCAPE_PARAM_ID,
-                    **dims,
-                },
-            )
+                out_cape = getattr(config.outputs, product.cape_output)
+                write_grib(
+                    out_cape.target,
+                    template,
+                    cape.astype(np.float32),
+                    {
+                        **out_cape.metadata,
+                        **pconfig.metadata,
+                        **dims,
+                    },
+                )
 
-            out_mucin = config.outputs.mucin
-            write_grib(
-                out_mucin.target,
-                template,
-                mucin.astype(np.float32),
-                {
-                    **out_mucin.metadata,
-                    **pconfig.metadata,
-                    "paramId": MUCIN_PARAM_ID,
-                    **dims,
-                },
-            )
+                out_cin = getattr(config.outputs, product.cin_output)
+                write_grib(
+                    out_cin.target,
+                    template,
+                    cin.astype(np.float32),
+                    {
+                        **out_cin.metadata,
+                        **pconfig.metadata,
+                        **dims,
+                    },
+                )
 
-    config.outputs.mucape.target.flush()
-    config.outputs.mucin.target.flush()
+    for product in config.cape_products:
+        getattr(config.outputs, product.cape_output).target.flush()
+        getattr(config.outputs, product.cin_output).target.flush()
     config.recovery.add_checkpoint(param=pconfig.name, **dims)
 
 

--- a/src/pproc/cape_cin.py
+++ b/src/pproc/cape_cin.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+# (C) Copyright 2021- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+import functools
+import logging
+import signal
+import sys
+
+import numpy as np
+from conflator import Conflator
+from earthkit.data import FieldList, SimpleFieldList
+from meters import ResourceMeter
+
+from earthkit.meteo import constants
+from earthkit.meteo.thermo import specific_humidity_from_dewpoint
+
+from pproc.cape.compute import compute_mucape_mucin
+from pproc.common.accumulation_manager import AccumulationManager
+from pproc.common.io import write_grib
+from pproc.common.parallel import parallel_processing, sigterm_handler
+from pproc.common.param_requester import ParamRequester
+from pproc.common.utils import dict_product
+from pproc.config.param import ParamConfig
+from pproc.config.types import CapeConfig
+
+logger = logging.getLogger(__name__)
+
+# GRIB paramId for MUCAPE and MUCIN
+MUCAPE_PARAM_ID = 228235
+MUCIN_PARAM_ID = 228236
+
+
+def cape_iteration(
+    config: CapeConfig,
+    pconfig: ParamConfig,
+    dims: dict,
+) -> None:
+    """Process one (step, …) slice: retrieve data, compute MUCAPE/MUCIN, write output."""
+    ids = ", ".join(f"{k}={v}" for k, v in dims.items())
+
+    fields = SimpleFieldList()
+    for src_name in config.inputs.names:
+        total = pconfig.compute_totalfields(config.inputs, src_name)
+        requester = ParamRequester(
+            pconfig,
+            config.inputs,
+            total,
+            src_name,
+        )
+        with ResourceMeter(f"Retrieve {src_name} {ids}"):
+            metadata, data = requester.retrieve_data(**dims)
+        fields += FieldList.from_array(data, [x.to_ekmetadata() for x in metadata])
+
+    with ResourceMeter(f"Compute CAPE/CIN {ids}"):
+        p_sfc = fields.sel(param="sp")
+        t_sfc = fields.sel(param="2t")
+        td_sfc = fields.sel(param="2d")
+        z_sfc = fields.sel(param="z", levtype="sfc")
+
+        t_pl = fields.sel(param="t").order_by(level="ascending", number="ascending")
+        q_pl = fields.sel(param="q").order_by(level="ascending", number="ascending")
+        z_pl = fields.sel(param="z", levtype="pl").order_by(
+            level="ascending", number="ascending"
+        )
+
+        n_members = len(p_sfc)
+        levels_sorted = sorted(config.pressure_levels)
+
+        sfc_template = t_sfc[0].metadata()
+
+        for member in range(n_members):
+            # Surface arrays
+            p_sfc_vals = p_sfc[member].values  # Pa
+            t_sfc_vals = t_sfc[member].values  # K
+            td_sfc_vals = td_sfc[member].values  # K
+            z_sfc_vals = z_sfc[member].values  # m²/s²
+
+            zh_sfc_vals = z_sfc_vals / constants.g  # m
+            q_sfc_vals = specific_humidity_from_dewpoint(td_sfc_vals, p_sfc_vals)
+
+
+            # PL arrays
+            n_points = p_sfc_vals.shape[0]
+            n_levels = len(levels_sorted)
+
+            t_arr = np.empty((n_levels, n_points), dtype=np.float64)
+            q_arr = np.empty((n_levels, n_points), dtype=np.float64)
+            zh_arr = np.empty((n_levels, n_points), dtype=np.float64)
+
+            for lev_idx, level in enumerate(levels_sorted):
+                t_field = t_pl.sel(level=level)
+                q_field = q_pl.sel(level=level)
+                z_field = z_pl.sel(level=level)
+
+                t_arr[lev_idx] = t_field[member].values
+                q_arr[lev_idx] = q_field[member].values
+                zh_arr[lev_idx] = z_field[member].values / constants.g  # geopotential → height
+
+            # Compute MUCAPE / MUCIN
+            mucape, mucin = compute_mucape_mucin(
+                t=t_arr,
+                q=q_arr,
+                zh=zh_arr,
+                p_levels_hpa=levels_sorted,
+                t_sfc=t_sfc_vals,
+                q_sfc=q_sfc_vals,
+                zh_sfc=zh_sfc_vals,
+                p_sfc=p_sfc_vals,
+            )
+
+            # Write GRIB output
+            template = sfc_template._handle
+
+            out_mucape = config.outputs.mucape
+            write_grib(
+                out_mucape.target,
+                template,
+                mucape.astype(np.float32),
+                {
+                    **out_mucape.metadata,
+                    **pconfig.metadata,
+                    "paramId": MUCAPE_PARAM_ID,
+                    **dims,
+                },
+            )
+
+            out_mucin = config.outputs.mucin
+            write_grib(
+                out_mucin.target,
+                template,
+                mucin.astype(np.float32),
+                {
+                    **out_mucin.metadata,
+                    **pconfig.metadata,
+                    "paramId": MUCIN_PARAM_ID,
+                    **dims,
+                },
+            )
+
+    config.outputs.mucape.target.flush()
+    config.outputs.mucin.target.flush()
+    config.recovery.add_checkpoint(param=pconfig.name, **dims)
+
+
+def main():
+    sys.stdout.reconfigure(line_buffering=True)
+    signal.signal(signal.SIGTERM, sigterm_handler)
+
+    cfg = Conflator(app_name="pproc-cape", model=CapeConfig).load()
+    cfg.initialise()
+    cfg.print()
+
+    plan = []
+    for param in cfg.parameters:
+        accum_manager = AccumulationManager.create(param.accumulations)
+        for dims in dict_product(accum_manager.dims):
+            if cfg.recovery.existing_checkpoint(param=param.name, **dims):
+                print(f"Recovery: skipping dims: {param.name} {dims}")
+                continue
+            plan.append((param, dims))
+
+    iteration = functools.partial(cape_iteration, cfg)
+    parallel_processing(
+        iteration,
+        plan,
+        cfg.parallelisation,
+    )
+
+    cfg.clean()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/pproc/cape_cin.py
+++ b/src/pproc/cape_cin.py
@@ -54,8 +54,10 @@ def cape_iteration(
             total,
             src_name,
         )
+        # Surface geopotential is only available at step 0
+        retrieve_dims = {**dims, "step": 0} if src_name == "zsfc" else dims
         with ResourceMeter(f"Retrieve {src_name} {ids}"):
-            metadata, data = requester.retrieve_data(**dims)
+            metadata, data = requester.retrieve_data(**retrieve_dims)
         fields += FieldList.from_array(data, [x.to_ekmetadata() for x in metadata])
 
     with ResourceMeter(f"Compute CAPE/CIN {ids}"):

--- a/src/pproc/config/factory.py
+++ b/src/pproc/config/factory.py
@@ -38,6 +38,7 @@ class ConfigFactory:
         "pproc-ecpoint": types.ECPointConfig,
         "pproc-clustereps": types.ClusterFullConfig,
         "pproc-flight-levels": types.FlightLevelsConfig,
+        "pproc-cape": types.CapeConfig,
     }
 
     @classmethod

--- a/src/pproc/config/io.py
+++ b/src/pproc/config/io.py
@@ -301,4 +301,6 @@ ClusterAttributionInputModel = create_input_model(
 FlightLevelsInputModel = create_input_model("FlightLevels", ["fc", "lnsp"])
 FlightLevelsOutputModel = create_output_model("FlightLevels", ["levels"])
 CapeInputModel = create_input_model("Cape", ["pl", "sfc", "zsfc"])
-CapeOutputModel = create_output_model("Cape", ["mucape", "mucin"])
+CapeOutputModel = create_output_model(
+    "Cape", ["mucape", "mucin", "mlcape50", "mlcin50", "mlcape100", "mlcin100"]
+)

--- a/src/pproc/config/io.py
+++ b/src/pproc/config/io.py
@@ -300,5 +300,5 @@ ClusterAttributionInputModel = create_input_model(
 )
 FlightLevelsInputModel = create_input_model("FlightLevels", ["fc", "lnsp"])
 FlightLevelsOutputModel = create_output_model("FlightLevels", ["levels"])
-CapeInputModel = create_input_model("Cape", ["pl", "sfc"])
+CapeInputModel = create_input_model("Cape", ["pl", "sfc", "zsfc"])
 CapeOutputModel = create_output_model("Cape", ["mucape", "mucin"])

--- a/src/pproc/config/io.py
+++ b/src/pproc/config/io.py
@@ -300,3 +300,5 @@ ClusterAttributionInputModel = create_input_model(
 )
 FlightLevelsInputModel = create_input_model("FlightLevels", ["fc", "lnsp"])
 FlightLevelsOutputModel = create_output_model("FlightLevels", ["levels"])
+CapeInputModel = create_input_model("Cape", ["pl", "sfc"])
+CapeOutputModel = create_output_model("Cape", ["mucape", "mucin"])

--- a/src/pproc/config/param.py
+++ b/src/pproc/config/param.py
@@ -42,6 +42,7 @@ class ParamConfig(BaseModel):
     metadata: Dict[str, Any] = {}
     total_fields: int = 0
     vod2uv: bool = False
+    split_params: bool = True
     _merge_exclude: tuple[str] = ("accumulations",)
 
     @model_validator(mode="after")
@@ -82,7 +83,7 @@ class ParamConfig(BaseModel):
                 continue
             fields = 1
             for key, value in req.items():
-                if key == "param" and not self.vod2uv:
+                if key == "param" and not self.vod2uv and self.split_params:
                     continue
                 if keys is None or key in keys:
                     fields *= np.size(value)
@@ -111,7 +112,7 @@ class ParamConfig(BaseModel):
             **inputs.overrides,
         )
 
-        if self.vod2uv:
+        if self.vod2uv or not self.split_params:
             requests = [reqs]
         else:
             requests = [list(expand(reqs, "param"))]

--- a/src/pproc/config/types.py
+++ b/src/pproc/config/types.py
@@ -776,6 +776,15 @@ class WindConfig(BaseConfig):
         return req
 
 
+class CapeProductConfig(ConfigModel):
+    """Configuration for a single CAPE/CIN product variant."""
+
+    parcel_type: str = "mu"
+    layer_depth: float | None = None
+    cape_output: str
+    cin_output: str
+
+
 class CapeConfig(BaseConfig):
     parallelisation: int = 1
     inputs: io.CapeInputModel
@@ -783,6 +792,13 @@ class CapeConfig(BaseConfig):
     parameters: list[ParamConfig]
     pressure_levels: list[int]
     model: str = "aifs"
+    cape_products: list[CapeProductConfig] = [
+        CapeProductConfig(
+            parcel_type="mu",
+            cape_output="mucape",
+            cin_output="mucin",
+        ),
+    ]
 
     @model_validator(mode="after")
     def validate_split_params(self) -> Self:
@@ -803,6 +819,22 @@ class CapeConfig(BaseConfig):
                 raise ValueError(
                     f"pressure_levels {self.pressure_levels} must match "
                     f"levelist {levelist} in pl input request"
+                )
+        return self
+
+    @model_validator(mode="after")
+    def validate_cape_product_outputs(self) -> Self:
+        output_names = set(self.outputs.names)
+        for product in self.cape_products:
+            if product.cape_output not in output_names:
+                raise ValueError(
+                    f"cape_output '{product.cape_output}' not in outputs: "
+                    f"{output_names}"
+                )
+            if product.cin_output not in output_names:
+                raise ValueError(
+                    f"cin_output '{product.cin_output}' not in outputs: "
+                    f"{output_names}"
                 )
         return self
 

--- a/src/pproc/config/types.py
+++ b/src/pproc/config/types.py
@@ -776,6 +776,37 @@ class WindConfig(BaseConfig):
         return req
 
 
+class CapeConfig(BaseConfig):
+    parallelisation: int = 1
+    inputs: io.CapeInputModel
+    outputs: io.CapeOutputModel = io.CapeOutputModel()
+    parameters: list[ParamConfig]
+    pressure_levels: list[int]
+    model: str = "aifs"
+
+    @model_validator(mode="after")
+    def validate_split_params(self) -> Self:
+        for param in self.parameters:
+            param.split_params = False
+        return self
+
+    @model_validator(mode="after")
+    def validate_pressure_levels(self) -> Self:
+        pl_request = self.inputs.pl.request
+        if isinstance(pl_request, list):
+            pl_request = pl_request[0]
+        levelist = pl_request.get("levelist", None)
+        if levelist is not None:
+            if set(self.pressure_levels) != set(
+                levelist if isinstance(levelist, list) else [levelist]
+            ):
+                raise ValueError(
+                    f"pressure_levels {self.pressure_levels} must match "
+                    f"levelist {levelist} in pl input request"
+                )
+        return self
+
+
 class ThermoParamConfig(ParamConfig):
     out_params: list[str | int]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,6 +107,7 @@ spaces:
             "cluster.grib",
             "has_missing.grib",
             "thermo.grib",
+            "cape.grib",
         ],
     )
 

--- a/tests/templates/cape.yaml
+++ b/tests/templates/cape.yaml
@@ -56,14 +56,52 @@ parameters:
     accumulations:
       step:
         coords: [[0], [6]]
+cape_products:
+  - parcel_type: mu
+    cape_output: mucape
+    cin_output: mucin
+  - parcel_type: mixed
+    layer_depth: 5000
+    cape_output: mlcape50
+    cin_output: mlcin50
+  - parcel_type: mixed
+    layer_depth: 10000
+    cape_output: mlcape100
+    cin_output: mlcin100
 outputs:
   mucape:
     target:
       type: fdb
     metadata:
       edition: 2
+      paramId: 228235
   mucin:
     target:
       type: fdb
     metadata:
       edition: 2
+      paramId: 228236
+  mlcape50:
+    target:
+      type: fdb
+    metadata:
+      edition: 2
+      paramId: 228231
+  mlcin50:
+    target:
+      type: fdb
+    metadata:
+      edition: 2
+      paramId: 228232
+  mlcape100:
+    target:
+      type: fdb
+    metadata:
+      edition: 2
+      paramId: 228233
+  mlcin100:
+    target:
+      type: fdb
+    metadata:
+      edition: 2
+      paramId: 228234

--- a/tests/templates/cape.yaml
+++ b/tests/templates/cape.yaml
@@ -1,0 +1,66 @@
+parallelisation: 1
+pressure_levels: [50, 100, 150, 200, 250, 300, 400, 500, 600, 700, 850, 925, 1000]
+inputs:
+  pl:
+    request:
+      class: ai
+      stream: oper
+      type: fc
+      expver: '0001'
+      model: aifs-single
+      date: 20260201
+      time: 0
+      levtype: pl
+      levelist: [50, 100, 150, 200, 250, 300, 400, 500, 600, 700, 850, 925, 1000]
+    source:
+      type: fdb
+  sfc:
+    request:
+      class: ai
+      stream: oper
+      type: fc
+      expver: '0001'
+      model: aifs-single
+      date: 20260201
+      time: 0
+      levtype: sfc
+    source:
+      type: fdb
+  zsfc:
+    request:
+      class: ai
+      stream: oper
+      type: fc
+      expver: '0001'
+      model: aifs-single
+      date: 20260201
+      time: 0
+      levtype: sfc
+    source:
+      type: fdb
+parameters:
+  cape:
+    inputs:
+      pl:
+        request:
+          param: [t, q, z]
+      sfc:
+        request:
+          param: [2t, 2d, sp]
+      zsfc:
+        request:
+          param: [z]
+    accumulations:
+      step:
+        coords: [[0], [6]]
+outputs:
+  mucape:
+    target:
+      type: fdb
+    metadata:
+      edition: 2
+  mucin:
+    target:
+      type: fdb
+    metadata:
+      edition: 2

--- a/tests/templates/cape.yaml
+++ b/tests/templates/cape.yaml
@@ -8,6 +8,7 @@ inputs:
       type: fc
       expver: '0001'
       model: aifs-single
+      domain: g
       date: 20260201
       time: 0
       levtype: pl
@@ -21,6 +22,7 @@ inputs:
       type: fc
       expver: '0001'
       model: aifs-single
+      domain: g
       date: 20260201
       time: 0
       levtype: sfc
@@ -33,6 +35,7 @@ inputs:
       type: fc
       expver: '0001'
       model: aifs-single
+      domain: g
       date: 20260201
       time: 0
       levtype: sfc

--- a/tests/templates/fdb/schema
+++ b/tests/templates/fdb/schema
@@ -121,6 +121,12 @@ method:     Integer;
                [ step, levelist?, param ]]
 ]
 
+# AI models (e.g. aifs-single)
+[ class=ai, expver, stream, date, time, domain?, model
+       [ type, levtype
+               [ step, levelist?, param ]]
+]
+
 ########################################################
 # The are the rules matching most of the fields
 # oper/dcda

--- a/tests/test_products.py
+++ b/tests/test_products.py
@@ -155,10 +155,10 @@ TEST_DIR = os.path.dirname(os.path.realpath(__file__))
                 "date": 20260201,
                 "time": 0,
                 "model": "aifs-single",
-                "param": [228235, 228236],
+                "param": [228231, 228232, 228233, 228234, 228235, 228236],
                 "step": [0, 6],
             },
-            4,
+            12,
         ],
     ],
     ids=[

--- a/tests/test_products.py
+++ b/tests/test_products.py
@@ -20,6 +20,7 @@ from pproc.quantiles import main as quantiles_main
 from pproc.wind import main as wind_main
 from pproc.thermal_indices import main as thermo_main
 from pproc.clustereps.__main__ import main as clustereps_main
+from pproc.cape_cin import main as cape_main
 from conftest import DATA_DIR
 
 TEST_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -143,6 +144,22 @@ TEST_DIR = os.path.dirname(os.path.realpath(__file__))
             },
             18,
         ],
+        [
+            "cape",
+            cape_main,
+            [],
+            {
+                "class": "ai",
+                "stream": "oper",
+                "type": "fc",
+                "date": 20260201,
+                "time": 0,
+                "model": "aifs-single",
+                "param": [228235, 228236],
+                "step": [0, 6],
+            },
+            4,
+        ],
     ],
     ids=[
         "prob",
@@ -153,6 +170,7 @@ TEST_DIR = os.path.dirname(os.path.realpath(__file__))
         "wind",
         "thermofeel",
         "clustereps",
+        "cape",
     ],
 )
 def test_products(tmpdir, monkeypatch, fdb, product, main, custom_args, req, length):


### PR DESCRIPTION
### Description
Adds an entrypoint to compute CAPE/CIN on AIFS outputs. Based on this PR in earthkit-meteo:https://github.com/ecmwf/earthkit-meteo/pull/163

Open questions:
- [ ] How do we handle output types of cape/cin? The current implementation is based on the assumption that we want to output mucape/mucin, mlcape50/mlcin50, and mlcape100/mucape100. Do we want to make this configurable? How do we handle paramIds?
- [ ] update to changes in earthkit-meteo API for cape/cin
- [ ] Need to test if processing the whole globe at once works for higher spatial resolutions.

Out of scope:
- IFS set-up (since cape/cin is an output of the IFS)
- maxCAPE/maxCIN (as it requires hourly resolution)

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
