### PR TITLE
Regional means entrypoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "eccodes >= 1.6.1",
     "filelock >= 3.12.0",
     "mir-python >= 0.2.0",
+    "netcdf4",
     "numexpr",
     "numpy >= 1.21.2",
     "pandas >= 1.3.3",
@@ -69,6 +70,7 @@ pproc-monthly-stats = "pproc.monthly_stats:main"
 pproc-config="pproc.config_generation:main"
 pproc-ecpoint = "pproc.ecpoint:main"
 pproc-flight-levels = "pproc.flight_levels:main"
+pproc-regional-means = "pproc.regional_means:main"
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/src/pproc/config/io.py
+++ b/src/pproc/config/io.py
@@ -28,6 +28,7 @@ from pproc.config import utils
 from pproc.config.targets import (
     FDBTarget,
     FileSetTarget,
+    DataFrameTarget,
     FileTarget,
     NullTarget,
     OverrideTargetWrapper,
@@ -155,6 +156,7 @@ class Output(ConfigModel):
             Annotated[NullTarget, Tag("null")],
             Annotated[FileTarget, Tag("file")],
             Annotated[FileSetTarget, Tag("fileset")],
+            Annotated[DataFrameTarget, Tag("dataframe")],
             Annotated[FDBTarget, Tag("fdb")],
             Annotated[OverrideTargetWrapper, Tag("override")],
         ],
@@ -301,4 +303,4 @@ ClusterAttributionInputModel = create_input_model(
 FlightLevelsInputModel = create_input_model("FlightLevels", ["fc", "lnsp"])
 FlightLevelsOutputModel = create_output_model("FlightLevels", ["levels"])
 RegionalMeansInputModel = create_input_model("RegionalMeans", ["fc"])
-RegionalMeansOutputModel = create_output_model("RegionalMeans", {})  # TODO should only allow file target
+RegionalMeansOutputModel = create_output_model("RegionalMeans", ["timeseries"])

--- a/src/pproc/config/io.py
+++ b/src/pproc/config/io.py
@@ -300,3 +300,5 @@ ClusterAttributionInputModel = create_input_model(
 )
 FlightLevelsInputModel = create_input_model("FlightLevels", ["fc", "lnsp"])
 FlightLevelsOutputModel = create_output_model("FlightLevels", ["levels"])
+RegionalMeansInputModel = create_input_model("RegionalMeans", ["fc"])
+RegionalMeansOutputModel = create_output_model("RegionalMeans", {})  # TODO should only allow file target

--- a/src/pproc/config/targets.py
+++ b/src/pproc/config/targets.py
@@ -165,13 +165,11 @@ class FDBTarget(Target):
 class _DataFrameColumns(BaseModel):
     index: list[str] = []
     values: list[str] = []
-
-    def __len__(self):
-        return len(self.index) + len(self.values)
+    # TODO consider allowing renaming: map from metadata key to column name
 
 
 class DataFrameTarget(Target):
-    """Collect individual rows of a DataFrame and write to file."""
+    """Collect individual rows of a DataFrame and write to a file."""
 
     type_: Literal["dataframe"] = Field("dataframe", alias="type")
     path: str
@@ -189,25 +187,27 @@ class DataFrameTarget(Target):
         return self
 
     def flush(self):
-        df = self.dataframe
-        with self._lock:
-            if self.format == "netcdf":
-                df.to_xarray().to_netcdf(self.path)
-            elif self.format == "csv":
-                # TODO csv would allow for incremental writes if rows don't have to be sorted
+        if self.format == "netcdf":
+            ds = self.dataframe.to_xarray()
+            with self._lock:
+                ds.to_netcdf(self.path)
+        elif self.format == "csv":
+            # TODO csv would allow for incremental writes if not sort_index
+            df = self.dataframe
+            with self._lock:
                 df.to_csv(self.path)
-            else:
-                raise NotImplementedError(self.format)
+        raise NotImplementedError(self.format)
 
     def write(self, index, values):
         if len(index) != len(self.columns.index):
-            raise ValueError(f"Expected {len(self.columns.index)} index columns, got {len(index)}")
+            raise ValueError(
+                f"Expected {len(self.columns.index)} index columns, got {len(index)}"
+            )
         if len(values) != len(self.columns.values):
-            raise ValueError(f"Expected {len(self.columns.values)} value columns, got {len(values)}")
+            raise ValueError(
+                f"Expected {len(self.columns.values)} value columns, got {len(values)}"
+            )
         self._rows.append([*index, *values])
-
-    def enable_recovery(self):
-        raise NotImplementedError
 
     def enable_parallel(self):
         self._rows = _shared_list()
@@ -221,10 +221,8 @@ class DataFrameTarget(Target):
         import pandas as pd
 
         columns = [*self.columns.index, *self.columns.values]
-        df = (
-            pd.DataFrame
-            .from_records(self._rows, columns=columns)
-            .set_index(self.columns.index)
+        df = pd.DataFrame.from_records(self._rows, columns=columns).set_index(
+            self.columns.index
         )
         if self.sort_index:
             df = df.sort_index()

--- a/src/pproc/config/targets.py
+++ b/src/pproc/config/targets.py
@@ -165,19 +165,21 @@ class FDBTarget(Target):
 class _DataFrameColumns(BaseModel):
     index: list[str] = []
     values: list[str] = []
+    # TODO consider allowing renaming: map from column names to metadata keys
 
     def __len__(self):
         return len(self.index) + len(self.values)
 
 
 class DataFrameTarget(Target):
-    """Collect individual rows of a DataFrame and write to file."""
+    """Collect individual rows of a DataFrame and write to a file."""
 
     type_: Literal["dataframe"] = Field("dataframe", alias="type")
     path: str
     format: Literal["netcdf"] | Literal["csv"]
     columns: _DataFrameColumns = _DataFrameColumns()
     sort_index: bool = True
+    clean_lock: bool = True
 
     _rows: list[Any] = []
     _lock: FileLock = None
@@ -189,46 +191,51 @@ class DataFrameTarget(Target):
         return self
 
     def flush(self):
-        df = self.dataframe
-        with self._lock:
-            if self.format == "netcdf":
-                df.to_xarray().to_netcdf(self.path)
-            elif self.format == "csv":
-                # TODO csv would allow for incremental writes if rows don't have to be sorted
+        if self.format == "netcdf":
+            ds = self.as_dataset()
+            with self._lock:
+                ds.to_netcdf(self.path)
+        elif self.format == "csv":
+            # TODO csv would allow for incremental writes if not sort_index
+            df = self.as_dataframe()
+            with self._lock:
                 df.to_csv(self.path)
-            else:
-                raise NotImplementedError(self.format)
+        raise NotImplementedError(self.format)
 
     def write(self, index, values):
         if len(index) != len(self.columns.index):
-            raise ValueError(f"Expected {len(self.columns.index)} index columns, got {len(index)}")
+            raise ValueError(
+                f"Expected {len(self.columns.index)} index columns, got {len(index)}"
+            )
         if len(values) != len(self.columns.values):
-            raise ValueError(f"Expected {len(self.columns.values)} value columns, got {len(values)}")
+            raise ValueError(
+                f"Expected {len(self.columns.values)} value columns, got {len(values)}"
+            )
         self._rows.append([*index, *values])
 
     def enable_recovery(self):
-        raise NotImplementedError
+        raise NotImplementedError("Recovery is not implemented for DataFrameTarget")
 
     def enable_parallel(self):
         self._rows = _shared_list()
 
     def clean(self):
-        if os.path.exists(self._lock.lock_file):
+        if self.clean_lock and os.path.exists(self._lock.lock_file):
             os.remove(self._lock.lock_file)
 
-    @property
-    def dataframe(self):
+    def as_dataframe(self):
         import pandas as pd
 
         columns = [*self.columns.index, *self.columns.values]
-        df = (
-            pd.DataFrame
-            .from_records(self._rows, columns=columns)
-            .set_index(self.columns.index)
+        df = pd.DataFrame.from_records(self._rows, columns=columns).set_index(
+            self.columns.index
         )
         if self.sort_index:
             df = df.sort_index()
         return df
+
+    def as_dataset(self):
+        return self.dataframe.to_xarray()
 
 
 class OverrideTargetWrapper(ConfigModel, Target):

--- a/src/pproc/config/targets.py
+++ b/src/pproc/config/targets.py
@@ -165,11 +165,13 @@ class FDBTarget(Target):
 class _DataFrameColumns(BaseModel):
     index: list[str] = []
     values: list[str] = []
-    # TODO consider allowing renaming: map from metadata key to column name
+
+    def __len__(self):
+        return len(self.index) + len(self.values)
 
 
 class DataFrameTarget(Target):
-    """Collect individual rows of a DataFrame and write to a file."""
+    """Collect individual rows of a DataFrame and write to file."""
 
     type_: Literal["dataframe"] = Field("dataframe", alias="type")
     path: str
@@ -187,27 +189,25 @@ class DataFrameTarget(Target):
         return self
 
     def flush(self):
-        if self.format == "netcdf":
-            ds = self.dataframe.to_xarray()
-            with self._lock:
-                ds.to_netcdf(self.path)
-        elif self.format == "csv":
-            # TODO csv would allow for incremental writes if not sort_index
-            df = self.dataframe
-            with self._lock:
+        df = self.dataframe
+        with self._lock:
+            if self.format == "netcdf":
+                df.to_xarray().to_netcdf(self.path)
+            elif self.format == "csv":
+                # TODO csv would allow for incremental writes if rows don't have to be sorted
                 df.to_csv(self.path)
-        raise NotImplementedError(self.format)
+            else:
+                raise NotImplementedError(self.format)
 
     def write(self, index, values):
         if len(index) != len(self.columns.index):
-            raise ValueError(
-                f"Expected {len(self.columns.index)} index columns, got {len(index)}"
-            )
+            raise ValueError(f"Expected {len(self.columns.index)} index columns, got {len(index)}")
         if len(values) != len(self.columns.values):
-            raise ValueError(
-                f"Expected {len(self.columns.values)} value columns, got {len(values)}"
-            )
+            raise ValueError(f"Expected {len(self.columns.values)} value columns, got {len(values)}")
         self._rows.append([*index, *values])
+
+    def enable_recovery(self):
+        raise NotImplementedError
 
     def enable_parallel(self):
         self._rows = _shared_list()
@@ -221,8 +221,10 @@ class DataFrameTarget(Target):
         import pandas as pd
 
         columns = [*self.columns.index, *self.columns.values]
-        df = pd.DataFrame.from_records(self._rows, columns=columns).set_index(
-            self.columns.index
+        df = (
+            pd.DataFrame
+            .from_records(self._rows, columns=columns)
+            .set_index(self.columns.index)
         )
         if self.sort_index:
             df = df.sort_index()

--- a/src/pproc/config/targets.py
+++ b/src/pproc/config/targets.py
@@ -162,6 +162,75 @@ class FDBTarget(Target):
         self.fdb.flush()
 
 
+class _DataFrameColumns(BaseModel):
+    index: list[str] = []
+    values: list[str] = []
+
+    def __len__(self):
+        return len(self.index) + len(self.values)
+
+
+class DataFrameTarget(Target):
+    """Collect individual rows of a DataFrame and write to file."""
+
+    type_: Literal["dataframe"] = Field("dataframe", alias="type")
+    path: str
+    format: Literal["netcdf"] | Literal["csv"]
+    columns: _DataFrameColumns = _DataFrameColumns()
+    sort_index: bool = True
+
+    _rows: list[Any] = []
+    _lock: FileLock = None
+
+    @model_validator(mode="after")
+    def create_lock(self) -> Self:
+        if self._lock is None:
+            self._lock = FileLock(self.path + ".lock", thread_local=False)
+        return self
+
+    def flush(self):
+        df = self.dataframe
+        with self._lock:
+            if self.format == "netcdf":
+                df.to_xarray().to_netcdf(self.path)
+            elif self.format == "csv":
+                # TODO csv would allow for incremental writes if rows don't have to be sorted
+                df.to_csv(self.path)
+            else:
+                raise NotImplementedError(self.format)
+
+    def write(self, index, values):
+        if len(index) != len(self.columns.index):
+            raise ValueError(f"Expected {len(self.columns.index)} index columns, got {len(index)}")
+        if len(values) != len(self.columns.values):
+            raise ValueError(f"Expected {len(self.columns.values)} value columns, got {len(values)}")
+        self._rows.append([*index, *values])
+
+    def enable_recovery(self):
+        raise NotImplementedError
+
+    def enable_parallel(self):
+        self._rows = _shared_list()
+
+    def clean(self):
+        if os.path.exists(self._lock.lock_file):
+            os.remove(self._lock.lock_file)
+
+    @property
+    def dataframe(self):
+        import pandas as pd
+
+        columns = [*self.columns.index, *self.columns.values]
+        df = (
+            pd.DataFrame
+            .from_records(self._rows, columns=columns)
+            .set_index(self.columns.index)
+        )
+        if self.sort_index:
+            df = df.sort_index()
+        return df
+
+
 class OverrideTargetWrapper(ConfigModel, Target):
     wrapped: Annotated[
         Union[NullTarget, FileTarget, FileSetTarget, FDBTarget],

--- a/src/pproc/config/targets.py
+++ b/src/pproc/config/targets.py
@@ -167,21 +167,18 @@ class _DataFrameColumns(BaseModel):
     values: list[str] = []
     # TODO consider allowing renaming: map from column names to metadata keys
 
-    def __len__(self):
-        return len(self.index) + len(self.values)
-
 
 class DataFrameTarget(Target):
-    """Collect individual rows of a DataFrame and write to a file."""
+    """Collect rows of a DataFrame and write to a file."""
 
     type_: Literal["dataframe"] = Field("dataframe", alias="type")
     path: str
-    format: Literal["netcdf"] | Literal["csv"]
+    format: Literal["csv"] | Literal["netcdf"]
     columns: _DataFrameColumns = _DataFrameColumns()
     sort_index: bool = True
     clean_lock: bool = True
 
-    _rows: list[Any] = []
+    _rows: list[tuple] = []
     _lock: FileLock = None
 
     @model_validator(mode="after")
@@ -191,18 +188,20 @@ class DataFrameTarget(Target):
         return self
 
     def flush(self):
-        if self.format == "netcdf":
-            ds = self.as_dataset()
-            with self._lock:
-                ds.to_netcdf(self.path)
-        elif self.format == "csv":
-            # TODO csv would allow for incremental writes if not sort_index
+        """Write the dataframe to disk, replacing an existing file if present."""
+        if self.format == "csv":
             df = self.as_dataframe()
             with self._lock:
                 df.to_csv(self.path)
-        raise NotImplementedError(self.format)
+        elif self.format == "netcdf":
+            ds = self.as_dataset()
+            with self._lock:
+                ds.to_netcdf(self.path)
+        else:
+            raise NotImplementedError(self.format)
 
     def write(self, index, values):
+        """Insert a new row into the dataframe."""
         if len(index) != len(self.columns.index):
             raise ValueError(
                 f"Expected {len(self.columns.index)} index columns, got {len(index)}"
@@ -211,10 +210,33 @@ class DataFrameTarget(Target):
             raise ValueError(
                 f"Expected {len(self.columns.values)} value columns, got {len(values)}"
             )
-        self._rows.append([*index, *values])
+        self._rows.append((*index, *values))
 
     def enable_recovery(self):
-        raise NotImplementedError("Recovery is not implemented for DataFrameTarget")
+        """Load all rows from a previoulsy written DataFrame."""
+        if not os.path.exists(self.path):
+            raise FileNotFoundError(f"recovery content not found: {self.path}")
+        if self.format == "csv":
+            # Pandas does not restore timedeltas as proper types, which results
+            # in a mixed str-timedelta column and inconsistent formatting
+            raise NotImplementedError("unable to recover from csv file")
+        if self.format == "netcdf":
+            import xarray as xr
+
+            with self._lock, xr.open_dataset(self.path) as ds:
+                df = ds.to_dataframe(dim_order=self.columns.index)
+        # Verify column order of recovered data
+        if df.index.names != self.columns.index:
+            raise ValueError(
+                f"Expected index columns {self.columns.index!r}, got {df.index.names!r}"
+            )
+        if list(df.columns) != self.columns.values:
+            raise ValueError(
+                f"Expected values columns {self.columns.values!r}, got {list(df.columns)!r}"
+            )
+        # Insert recovered rows
+        for row in df.reset_index().itertuples(index=False):
+            self._rows.append(tuple(row))
 
     def enable_parallel(self):
         self._rows = _shared_list()
@@ -224,6 +246,7 @@ class DataFrameTarget(Target):
             os.remove(self._lock.lock_file)
 
     def as_dataframe(self):
+        """Assemble the collected rows into a pandas.DataFrame."""
         import pandas as pd
 
         columns = [*self.columns.index, *self.columns.values]
@@ -235,7 +258,8 @@ class DataFrameTarget(Target):
         return df
 
     def as_dataset(self):
-        return self.dataframe.to_xarray()
+        """Assemble the collected rows into an xarray.Dataset."""
+        return self.as_dataframe().to_xarray()
 
 
 class OverrideTargetWrapper(ConfigModel, Target):

--- a/src/pproc/config/types.py
+++ b/src/pproc/config/types.py
@@ -1714,13 +1714,8 @@ class FlightLevelsConfig(AccumConfig):
         return req
 
 
-class RegionalMeansParamConfig(ParamConfig):
-    out_coords: list[str]  # coordinates preserved in the output
-    areas: dict[str, tuple[float, float, float, float]]  # N, W, S, E bounding box
-
-
 class RegionalMeansConfig(AccumConfig):
-    parallelisation: Parallelisation = Parallelisation()
+    parallelisation: int
     inputs: io.RegionalMeansInputModel
     outputs: io.RegionalMeansOutputModel = io.RegionalMeansOutputModel()
-    parameters: list[RegionalMeansParamConfig]
+    bbox: dict[str, tuple[float, float, float, float]]  # N, W, S, E bounding boxes

--- a/src/pproc/config/types.py
+++ b/src/pproc/config/types.py
@@ -1712,3 +1712,15 @@ class FlightLevelsConfig(AccumConfig):
         req["levtype"] = "fl"
         req["levelist"] = self.target_flight_levels
         return req
+
+
+class RegionalMeansParamConfig(ParamConfig):
+    out_coords: list[str]  # coordinates preserved in the output
+    areas: dict[str, tuple[float, float, float, float]]  # N, W, S, E bounding box
+
+
+class RegionalMeansConfig(AccumConfig):
+    parallelisation: Parallelisation = Parallelisation()
+    inputs: io.RegionalMeansInputModel
+    outputs: io.RegionalMeansOutputModel = io.RegionalMeansOutputModel()
+    parameters: list[RegionalMeansParamConfig]

--- a/src/pproc/regional_means.py
+++ b/src/pproc/regional_means.py
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+# SPDX-License-Identifier: Apache-2.0
+
+import concurrent.futures
+import signal
+import sys
+
+from conflator import Conflator
+from earthkit.data import Field, ArrayField
+from meters import ResourceMeter
+import numpy as np
+import pandas as pd
+
+from pproc.common.accumulation_manager import AccumulationManager
+from pproc.common.parallel import (
+    create_executor,
+    sigterm_handler,
+)
+from pproc.common.param_requester import ParamRequester
+from pproc.common.utils import dict_product
+from pproc.config.types import RegionalMeansParamConfig, RegionalMeansConfig
+
+
+def crop(field: Field, bbox):
+    """Latitude and field values cropped to a lat-lon bounding box"""
+    lat, lon, values = field.data(["lat", "lon", "value"], flatten=True)
+    n, w, s, e = bbox
+    mask = (n >= lat) & (lat >= s) & (e >= lon) & (lon >= w)
+    return lat[mask], values[mask]
+
+
+def area_weighted_mean(field: Field, area) -> float:
+    """Area-weighted mean of the field in a lat-lon bounding box
+    
+    cos(lat) weighting assumes a lat-lon grid with regularly spaced latitudes
+    """
+    lat, values = crop(field, area)
+    area_weights = np.cos(np.deg2rad(lat))
+    return np.average(values, weights=area_weights)
+
+
+def regional_mean_iteration(
+    config: RegionalMeansConfig,
+    pconfig: RegionalMeansParamConfig,
+    dims: dict
+):
+    ids = ", ".join(f"{k}={v}" for k, v in dims.items())
+    rows = []
+    for src_name in config.inputs.names:
+        src_param = getattr(pconfig, src_name, pconfig)
+        total = pconfig.compute_totalfields(config.inputs, src_name)
+        requester = ParamRequester(src_param, config.inputs, total, src_name)
+        with ResourceMeter(f"Retrieve {src_name} {ids}"):
+            metadata, data = requester.retrieve_data(**dims)
+        with ResourceMeter("Compute means"):
+            for md, arr in zip(metadata, data):
+                field = ArrayField(arr, md.to_ekmetadata())
+                rows.append([
+                    *field.metadata(pconfig.out_coords),
+                    *(area_weighted_mean(field, bbox) for bbox in pconfig.areas.values())
+                ])
+    return pd.DataFrame.from_records(rows, columns=[
+        *pconfig.out_coords,
+        *(f"{pconfig.name}_{name}" for name in pconfig.areas.keys())
+    ])
+
+
+def main():
+    sys.stdout.reconfigure(line_buffering=True)
+    signal.signal(signal.SIGTERM, sigterm_handler)
+
+    cfg = Conflator(app_name="pproc-regional-means", model=RegionalMeansConfig).load()
+    cfg.initialise()
+    cfg.print()
+
+    with create_executor(cfg.parallelisation) as executor:
+        futures = []
+        for param in cfg.parameters:
+            accum_manager = AccumulationManager.create(
+                param.accumulations,
+            )
+            for dims in dict_product(accum_manager.dims):
+                if cfg.recovery.existing_checkpoint(param=param.name, **dims):
+                    print(f"Recovery: skipping dims: {param.name} {dims}")
+                    continue  # TODO should create a future that loads already computed data
+
+                futures.append(
+                    executor.submit(regional_mean_iteration, cfg, param, dims)
+                )
+
+        # TODO needs more complexity when there are multiple parameters
+        df = pd.concat([future.result() for future in concurrent.futures.as_completed(futures)])
+
+    # Parse dates and datetimes (TODO earthkit-data 1.0 should remove the need for this)
+    if "forecast_reference_time" in df.columns:
+        df["forecast_reference_time"] = pd.to_datetime(df["forecast_reference_time"])
+    if "step" in df.columns:
+        df["step"] = pd.to_timedelta(df["step"], unit="h")
+
+    with ResourceMeter(f"Write to {cfg.outputs.default.target.path}"):
+        ds = df.set_index(param.out_coords).sort_index().to_xarray()
+        # TODO: covjson output
+        ds.to_netcdf(cfg.outputs.default.target.path)
+
+    cfg.clean()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/pproc/regional_means.py
+++ b/src/pproc/regional_means.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
 # SPDX-License-Identifier: Apache-2.0
 
-import concurrent.futures
+import functools
 import signal
 import sys
 
@@ -13,16 +13,16 @@ import pandas as pd
 
 from pproc.common.accumulation_manager import AccumulationManager
 from pproc.common.parallel import (
-    create_executor,
+    parallel_processing,
     sigterm_handler,
 )
 from pproc.common.param_requester import ParamRequester
 from pproc.common.utils import dict_product
-from pproc.config.types import RegionalMeansParamConfig, RegionalMeansConfig
+from pproc.config.types import ParamConfig, RegionalMeansConfig
 
 
 def crop(field: Field, bbox):
-    """Latitude and field values cropped to a lat-lon bounding box"""
+    """Latitude and field values cropped to a lat-lon bounding box."""
     lat, lon, values = field.data(["lat", "lon", "value"], flatten=True)
     n, w, s, e = bbox
     mask = (n >= lat) & (lat >= s) & (e >= lon) & (lon >= w)
@@ -30,22 +30,31 @@ def crop(field: Field, bbox):
 
 
 def area_weighted_mean(field: Field, area) -> float:
-    """Area-weighted mean of the field in a lat-lon bounding box
-    
-    cos(lat) weighting assumes a lat-lon grid with regularly spaced latitudes
+    """Area-weighted mean of the field in a lat-lon bounding box.
+
+    cos(lat) weighting assumes a lat-lon grid with regularly spaced latitudes.
     """
     lat, values = crop(field, area)
     area_weights = np.cos(np.deg2rad(lat))
     return np.average(values, weights=area_weights)
 
 
+def get_metadata(field, key):
+    value = field.metadata(key)
+    if key == "forecast_reference_time":
+        return pd.to_datetime(value)
+    if key == "step":
+        return pd.to_timedelta(value, unit="h")
+    return value
+
+
 def regional_mean_iteration(
     config: RegionalMeansConfig,
-    pconfig: RegionalMeansParamConfig,
+    pconfig: ParamConfig,
     dims: dict
 ):
     ids = ", ".join(f"{k}={v}" for k, v in dims.items())
-    rows = []
+    target = config.outputs.timeseries.target
     for src_name in config.inputs.names:
         src_param = getattr(pconfig, src_name, pconfig)
         total = pconfig.compute_totalfields(config.inputs, src_name)
@@ -55,14 +64,13 @@ def regional_mean_iteration(
         with ResourceMeter("Compute means"):
             for md, arr in zip(metadata, data):
                 field = ArrayField(arr, md.to_ekmetadata())
-                rows.append([
-                    *field.metadata(pconfig.out_coords),
-                    *(area_weighted_mean(field, bbox) for bbox in pconfig.areas.values())
-                ])
-    return pd.DataFrame.from_records(rows, columns=[
-        *pconfig.out_coords,
-        *(f"{pconfig.name}_{name}" for name in pconfig.areas.keys())
-    ])
+                target.write(
+                    index=[get_metadata(field, key) for key in target.columns.index],
+                    values=[
+                        area_weighted_mean(field, config.bbox[region])
+                        for region in target.columns.values
+                    ],
+                )
 
 
 def main():
@@ -73,34 +81,26 @@ def main():
     cfg.initialise()
     cfg.print()
 
-    with create_executor(cfg.parallelisation) as executor:
-        futures = []
-        for param in cfg.parameters:
-            accum_manager = AccumulationManager.create(
-                param.accumulations,
-            )
-            for dims in dict_product(accum_manager.dims):
-                if cfg.recovery.existing_checkpoint(param=param.name, **dims):
-                    print(f"Recovery: skipping dims: {param.name} {dims}")
-                    continue  # TODO should create a future that loads already computed data
+    plan = []
+    for param in cfg.parameters:
+        accum_manager = AccumulationManager.create(
+            param.accumulations,
+        )
+        for dims in dict_product(accum_manager.dims):
+            if cfg.recovery.existing_checkpoint(param=param.name, **dims):
+                print(f"Recovery: skipping dims: {param.name} {dims}")
+                continue
+            plan.append((param, dims))
 
-                futures.append(
-                    executor.submit(regional_mean_iteration, cfg, param, dims)
-                )
+    iteration = functools.partial(regional_mean_iteration, cfg)
+    parallel_processing(
+        iteration,
+        plan,
+        cfg.parallelisation,
+    )
 
-        # TODO needs more complexity when there are multiple parameters
-        df = pd.concat([future.result() for future in concurrent.futures.as_completed(futures)])
-
-    # Parse dates and datetimes (TODO earthkit-data 1.0 should remove the need for this)
-    if "forecast_reference_time" in df.columns:
-        df["forecast_reference_time"] = pd.to_datetime(df["forecast_reference_time"])
-    if "step" in df.columns:
-        df["step"] = pd.to_timedelta(df["step"], unit="h")
-
-    with ResourceMeter(f"Write to {cfg.outputs.default.target.path}"):
-        ds = df.set_index(param.out_coords).sort_index().to_xarray()
-        # TODO: covjson output
-        ds.to_netcdf(cfg.outputs.default.target.path)
+    cfg.outputs.timeseries.target.flush()
+    cfg.outputs.timeseries.target.clean()
 
     cfg.clean()
 

--- a/src/pproc/regional_means.py
+++ b/src/pproc/regional_means.py
@@ -62,6 +62,7 @@ def regional_mean_iteration(
         with ResourceMeter(f"Retrieve {src_name} {ids}"):
             metadata, data = requester.retrieve_data(**dims)
         with ResourceMeter("Compute means"):
+            # One row output for each field input, one value/column per region
             for md, arr in zip(metadata, data):
                 field = ArrayField(arr, md.to_ekmetadata())
                 target.write(
@@ -100,8 +101,6 @@ def main():
     )
 
     cfg.outputs.timeseries.target.flush()
-    cfg.outputs.timeseries.target.clean()
-
     cfg.clean()
 
 

--- a/src/pproc/regional_means.py
+++ b/src/pproc/regional_means.py
@@ -62,6 +62,7 @@ def regional_mean_iteration(
         with ResourceMeter(f"Retrieve {src_name} {ids}"):
             metadata, data = requester.retrieve_data(**dims)
         with ResourceMeter("Compute means"):
+            # One row output for each field input, one value/column per region
             for md, arr in zip(metadata, data):
                 field = ArrayField(arr, md.to_ekmetadata())
                 target.write(
@@ -71,6 +72,9 @@ def regional_mean_iteration(
                         for region in target.columns.values
                     ],
                 )
+
+    target.flush()
+    config.recovery.add_checkpoint(param=pconfig.name, **dims)
 
 
 def main():
@@ -98,9 +102,6 @@ def main():
         plan,
         cfg.parallelisation,
     )
-
-    cfg.outputs.timeseries.target.flush()
-    cfg.outputs.timeseries.target.clean()
 
     cfg.clean()
 

--- a/src/pproc/regional_means.py
+++ b/src/pproc/regional_means.py
@@ -62,7 +62,6 @@ def regional_mean_iteration(
         with ResourceMeter(f"Retrieve {src_name} {ids}"):
             metadata, data = requester.retrieve_data(**dims)
         with ResourceMeter("Compute means"):
-            # One row output for each field input, one value/column per region
             for md, arr in zip(metadata, data):
                 field = ArrayField(arr, md.to_ekmetadata())
                 target.write(
@@ -72,9 +71,6 @@ def regional_mean_iteration(
                         for region in target.columns.values
                     ],
                 )
-
-    target.flush()
-    config.recovery.add_checkpoint(param=pconfig.name, **dims)
 
 
 def main():
@@ -102,6 +98,9 @@ def main():
         plan,
         cfg.parallelisation,
     )
+
+    cfg.outputs.timeseries.target.flush()
+    cfg.outputs.timeseries.target.clean()
 
     cfg.clean()
 

--- a/src/pproc/regional_means.py
+++ b/src/pproc/regional_means.py
@@ -72,6 +72,8 @@ def regional_mean_iteration(
                         for region in target.columns.values
                     ],
                 )
+    target.flush()
+    config.recovery.add_checkpoint(param=pconfig.name, **dims)
 
 
 def main():
@@ -100,7 +102,6 @@ def main():
         cfg.parallelisation,
     )
 
-    cfg.outputs.timeseries.target.flush()
     cfg.clean()
 
 

--- a/tests/templates/regional_means.yaml
+++ b/tests/templates/regional_means.yaml
@@ -1,0 +1,45 @@
+checkpointing:
+  enable: false
+
+parallelisation:
+  n_par_compute: 2
+  n_par_read: 2
+  queue_size: 2
+
+parameters:
+  u:
+    inputs:
+      fc:
+        request:
+          param: 131
+    out_coords:
+      - number
+      - forecast_reference_time
+      - step
+    areas:
+      nh: [62, 0, 58, 360]
+      sh: [-58, 0, -62, 360]
+
+inputs:
+  fc:
+    request:
+      - class: od
+        type: pf
+        stream: eefo
+        expver: '0001'
+        levtype: pl
+        levelist: 10
+        date: '20260721'
+        time: '0000'
+        step: [0, 24, 48, 72, 96, 120, 144, 168, 192, 216, 240, 264, 288, 312, 336, 360, 384, 408, 432, 456, 480, 504, 528, 552, 576, 600, 624, 648, 672, 696, 720, 744, 768, 792, 816, 840, 864, 888, 912, 936, 960, 984, 1008, 1032, 1056, 1080]
+        number: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100]
+        domain: g
+        grid: '1.0/1.0'
+    source:
+      type: mars
+
+outputs:
+  default:
+    target:
+      type: file
+      path: '2026-07-21_eefo_pf_zwzm.nc'

--- a/tests/templates/regional_means.yaml
+++ b/tests/templates/regional_means.yaml
@@ -1,10 +1,7 @@
 checkpointing:
   enable: false
 
-parallelisation:
-  n_par_compute: 2
-  n_par_read: 2
-  queue_size: 2
+parallelisation: 2
 
 parameters:
   u:
@@ -12,13 +9,6 @@ parameters:
       fc:
         request:
           param: 131
-    out_coords:
-      - number
-      - forecast_reference_time
-      - step
-    areas:
-      nh: [62, 0, 58, 360]
-      sh: [-58, 0, -62, 360]
 
 inputs:
   fc:
@@ -29,7 +19,7 @@ inputs:
         expver: '0001'
         levtype: pl
         levelist: 10
-        date: '20260721'
+        date: '20260729'
         time: '0000'
         step: [0, 24, 48, 72, 96, 120, 144, 168, 192, 216, 240, 264, 288, 312, 336, 360, 384, 408, 432, 456, 480, 504, 528, 552, 576, 600, 624, 648, 672, 696, 720, 744, 768, 792, 816, 840, 864, 888, 912, 936, 960, 984, 1008, 1032, 1056, 1080]
         number: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100]
@@ -39,7 +29,21 @@ inputs:
       type: mars
 
 outputs:
-  default:
+  timeseries:
     target:
-      type: file
-      path: '2026-07-21_eefo_pf_zwzm.nc'
+      type: dataframe
+      path: 'test.nc'
+      format: 'netcdf'
+      columns:
+        index:
+          - number
+          - forecast_reference_time
+          - step
+        values:
+          - nh
+          - sh
+      sort_index: true
+
+bbox:
+  nh: [62, 0, 58, 360]
+  sh: [-58, 0, -62, 360]

--- a/tests/templates/regional_means.yaml
+++ b/tests/templates/regional_means.yaml
@@ -1,5 +1,5 @@
 checkpointing:
-  enable: false
+  enable: true
 
 parallelisation: 2
 


### PR DESCRIPTION
### Description

Compute regional area-weighted means.

- Area weights are based on the cosine of latitude (valid for rectilinear grids with regular latitude coordinates).
- Areas are specified with a rectangular bounding box in lat and lon.
- The output contains one column/variable per configured region. (not good, see below)

To compute zonal-mean zonal wind for https://charts.ecmwf.int/products/extended-zonal-mean-zonal-wind.


### New DataFrameTarget

Introduces `pproc.config.targets.DataFrameTarget` to collect rows of an output table as they are produced, then write the table in different formats to disk.

- The table structure (index and value columns) is specified in the target configuration.
- Available output formats: csv, netcdf. Still missing covjson.
- `flush()` does not implement incremental writes but replaces the entire target file every time.
- Checkpointing is available, but previous results can only be recovered from netcdf format.

### Open issues

- Setting additional metadata for the target (parameter names, units, information about the domains, etc.).
- I'm not particularly happy with how multiple parameters and regions are handled. I'd prefer to have region as a coordinate/index and split parameters into variables/columns (this should be much closer to CF conventions). At the moment all parameters are mixed in the table unless explicitly separated with a coordinate and regions are split into variables.


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
