### PR TITLE
Support for GRIB 2 SOT quantile keys

### DIFF
--- a/src/pproc/common/accumulation.py
+++ b/src/pproc/common/accumulation.py
@@ -60,10 +60,10 @@ def coords_name(coords: Coords, name_config: Optional[dict] = None) -> str:
 
 def coords_span(dim: str, start: Coord, end: Coord) -> Optional[int]:
     if dim == "date":
-        return (parse_date(end) - parse_date(start)).days
+        return (parse_date(str(end)) - parse_date(str(start))).days
 
     if dim == "hdate":
-        return parse_date(end).year - parse_date(start).year
+        return parse_date(str(end)).year - parse_date(str(start)).year
 
     if isinstance(start, int) and isinstance(end, int):
         return end - start
@@ -78,12 +78,12 @@ def coords_increment(dim: str, coords: Coords) -> Optional[int]:
         return 0
 
     if dim == "date":
-        diff = np.diff([parse_date(c) for c in coords])
+        diff = np.diff([parse_date(str(c)) for c in coords])
         if np.all(diff == diff[0]):
             return diff[0].days
 
     if dim == "hdate":
-        diff = np.diff([parse_date(c).year for c in coords])
+        diff = np.diff([parse_date(str(c)).year for c in coords])
         if np.all(diff == diff[0]):
             return diff[0]
 

--- a/src/pproc/common/accumulation.py
+++ b/src/pproc/common/accumulation.py
@@ -17,11 +17,10 @@ from typing import Dict, Iterable, List, Optional, Tuple, Union
 import numpy as np
 from numpy.typing import DTypeLike
 
-from earthkit.time.calendar import MonthInYear
+from earthkit.time.calendar import MonthInYear, parse_date
 from earthkit.time.sequence import MonthlySequence
 
 from pproc.common.grib_helpers import fill_template_values
-
 
 NumericCoord = int
 NumericCoords = Union[List[int], range]
@@ -57,6 +56,45 @@ def coords_name(coords: Coords, name_config: Optional[dict] = None) -> str:
     else:
         raise ValueError(f"Unknown name type {name_type}")
     return f"{prefix}{start}-{end}{suffix}"
+
+
+def coords_span(dim: str, start: Coord, end: Coord) -> Optional[int]:
+    if dim == "date":
+        return (parse_date(end) - parse_date(start)).days
+
+    if dim == "hdate":
+        return parse_date(end).year - parse_date(start).year
+
+    if isinstance(start, int) and isinstance(end, int):
+        return end - start
+
+    # Can not determine span for non-numeric/date coords. Return
+    # value that will raise error if set
+    return None
+
+
+def coords_increment(dim: str, coords: Coords) -> Optional[int]:
+    if len(coords) == 1:
+        return 0
+
+    if dim == "date":
+        diff = np.diff([parse_date(c) for c in coords])
+        if np.all(diff == diff[0]):
+            return diff[0].days
+
+    if dim == "hdate":
+        diff = np.diff([parse_date(c).year for c in coords])
+        if np.all(diff == diff[0]):
+            return diff[0]
+
+    if all(isinstance(c, int) for c in coords):
+        diff = np.diff(coords)
+        if np.all(diff == diff[0]):
+            return diff[0]
+
+    # Couldn't determine increment, either non-unique or non-numeric/date
+    # coords. Return value that will raise error if set
+    return None
 
 
 class Accumulation(metaclass=ABCMeta):
@@ -145,6 +183,8 @@ class Accumulation(metaclass=ABCMeta):
                 "num_coords": len(self.coords),
                 "start_coord": start,
                 "end_coord": end,
+                "coords_span": coords_span(dim, start, end),
+                "coords_increment": coords_increment(dim, self.coords),
             },
         )
 

--- a/src/pproc/common/grib_helpers.py
+++ b/src/pproc/common/grib_helpers.py
@@ -59,6 +59,7 @@ def construct_message(template_grib, metadata: dict):
 
 
 _TEMPLATE_RE = re.compile("^{([a-z_]*)}:?([a-z]*)$", re.I)
+_EXPR_TEMPLATE_RE = re.compile(r"^\{([^{}]+)\}$")
 _TYPES = {
     "int": int,
     "str": str,
@@ -69,7 +70,14 @@ _TYPES = {
 def fill_template_value(val: str, template_map: dict):
     m = _TEMPLATE_RE.fullmatch(val)
     if m is None:
-        return val
+        expr_match = _EXPR_TEMPLATE_RE.fullmatch(val)
+        if expr_match is None:
+            return val
+        return eval(
+            expr_match.group(1).strip(),
+            {"__builtins__": {}},
+            {**_TYPES, **template_map},
+        )
     value, tp = m.groups()
     if value not in template_map:
         return val

--- a/src/pproc/common/grib_helpers.py
+++ b/src/pproc/common/grib_helpers.py
@@ -69,24 +69,21 @@ _TYPES = {
 
 def fill_template_value(val: str, template_map: dict):
     m = _TEMPLATE_RE.fullmatch(val)
-    if m is None:
-        expr_match = _EXPR_TEMPLATE_RE.fullmatch(val)
-        if expr_match is None:
+    if m is not None:
+        value, tp = m.groups()
+        if value not in template_map:
             return val
-        try:
-            return eval(
-                expr_match.group(1).strip(),
-                {"__builtins__": {}},
-                {**_TYPES, **template_map},
-            )
-        except NameError:
-            return val
-    value, tp = m.groups()
-    if value not in template_map:
+        return template_map[value] if len(tp) == 0 else _TYPES[tp](template_map[value])
+        
+    expr_match = _EXPR_TEMPLATE_RE.fullmatch(val)
+    in_map = any(k in val for k in template_map.keys())
+    if expr_match is None or not in_map:
         return val
-
-    return template_map[value] if len(tp) == 0 else _TYPES[tp](template_map[value])
-
+    return eval(
+        expr_match.group(1).strip(),
+        {"__builtins__": {}},
+        {**_TYPES, **template_map},
+    )
 
 def fill_template_values(metadata: dict, template_map: dict) -> dict:
     metadata = metadata.copy()

--- a/src/pproc/common/grib_helpers.py
+++ b/src/pproc/common/grib_helpers.py
@@ -73,11 +73,14 @@ def fill_template_value(val: str, template_map: dict):
         expr_match = _EXPR_TEMPLATE_RE.fullmatch(val)
         if expr_match is None:
             return val
-        return eval(
-            expr_match.group(1).strip(),
-            {"__builtins__": {}},
-            {**_TYPES, **template_map},
-        )
+        try:
+            return eval(
+                expr_match.group(1).strip(),
+                {"__builtins__": {}},
+                {**_TYPES, **template_map},
+            )
+        except NameError:
+            return val
     value, tp = m.groups()
     if value not in template_map:
         return val
@@ -90,4 +93,9 @@ def fill_template_values(metadata: dict, template_map: dict) -> dict:
     for key, val in metadata.items():
         if isinstance(val, str):
             metadata[key] = fill_template_value(val, template_map)
+        if isinstance(val, list):
+            metadata[key] = [
+                fill_template_value(v, template_map) if isinstance(v, str) else v
+                for v in val
+            ]
     return metadata

--- a/src/pproc/common/grib_helpers.py
+++ b/src/pproc/common/grib_helpers.py
@@ -28,7 +28,11 @@ def construct_message(template_grib, metadata: dict):
     arr_grib_keys = {
         key: value for key, value in metadata.items() if np.ndim(value) > 0
     }
-    missing = [key for key, value in metadata.items() if value == "MISSING"]
+    missing = [
+        key
+        for key, value in metadata.items()
+        if key not in arr_grib_keys and value == "MISSING"
+    ]
     for arr_key in missing + list(arr_grib_keys.keys()):
         key_values.pop(arr_key)
 
@@ -74,7 +78,7 @@ def fill_template_value(val: str, template_map: dict):
         if value not in template_map:
             return val
         return template_map[value] if len(tp) == 0 else _TYPES[tp](template_map[value])
-        
+
     expr_match = _EXPR_TEMPLATE_RE.fullmatch(val)
     in_map = any(k in val for k in template_map.keys())
     if expr_match is None or not in_map:
@@ -84,6 +88,7 @@ def fill_template_value(val: str, template_map: dict):
         {"__builtins__": {}},
         {**_TYPES, **template_map},
     )
+
 
 def fill_template_values(metadata: dict, template_map: dict) -> dict:
     metadata = metadata.copy()

--- a/src/pproc/config/recovery.py
+++ b/src/pproc/config/recovery.py
@@ -91,7 +91,7 @@ class Recovery(BaseRecovery):
 
         else:
             self.clean()
-       self._lock = None
+        self._lock = None
 
     @property
     def lock(self) -> FileLock:

--- a/src/pproc/config/recovery.py
+++ b/src/pproc/config/recovery.py
@@ -91,13 +91,10 @@ class Recovery(BaseRecovery):
 
         else:
             self.clean()
-        self._lock = None
 
     @property
     def lock(self) -> FileLock:
-        if self._lock is None:
-            self._lock =  FileLock(self.filename + ".lock", thread_local=False)
-        return self._lock
+        return FileLock(self.filename + ".lock", thread_local=False)
 
     def computed(self, **matching) -> List[dict]:
         ret = []
@@ -147,8 +144,8 @@ class Recovery(BaseRecovery):
         """
         if os.path.exists(self.filename):
             os.remove(self.filename)
-        if os.path.exists(self.filename + ".lock"):
-            os.remove(self.filename + ".lock")
+        if os.path.exists(self.lock.lock_file):
+            os.remove(self.lock.lock_file)
 
 
 def create_recovery(

--- a/src/pproc/config/recovery.py
+++ b/src/pproc/config/recovery.py
@@ -91,7 +91,13 @@ class Recovery(BaseRecovery):
 
         else:
             self.clean()
-        self.lock = FileLock(self.filename + ".lock", thread_local=False)
+       self._lock = None
+
+    @property
+    def lock(self) -> FileLock:
+        if self._lock is None:
+            self._lock =  FileLock(self.filename + ".lock", thread_local=False)
+        return self._lock
 
     def computed(self, **matching) -> List[dict]:
         ret = []

--- a/src/pproc/config/targets.py
+++ b/src/pproc/config/targets.py
@@ -70,13 +70,10 @@ class FileTarget(Target):
     clean_lock: bool = True
 
     _opened_files: list[str] = []
-    _lock: FileLock = None
 
     @property
     def lock(self) -> FileLock:
-        if self._lock is None:
-            self._lock =  FileLock(self.path + ".lock", thread_local=False)
-        return self._lock
+        return FileLock(self.path + ".lock", thread_local=False)
 
     @property
     def mode(self):

--- a/src/pproc/config/targets.py
+++ b/src/pproc/config/targets.py
@@ -72,11 +72,11 @@ class FileTarget(Target):
     _opened_files: list[str] = []
     _lock: FileLock = None
 
-    @model_validator(mode="after")
-    def create_lock(self) -> Self:
+    @property
+    def lock(self) -> FileLock:
         if self._lock is None:
-            self._lock = FileLock(self.path + ".lock", thread_local=False)
-        return self
+            self._lock =  FileLock(self.path + ".lock", thread_local=False)
+        return self._lock
 
     @property
     def mode(self):
@@ -92,14 +92,14 @@ class FileTarget(Target):
         self._opened_files = _shared_list()
 
     def write(self, message):
-        with self._lock:
+        with self.lock:
             with open(self.path, self.mode) as file:
                 message.write_to(file)
 
     def clean(self):
         if self.clean_lock:
-            if os.path.exists(self._lock.lock_file):
-                os.remove(self._lock.lock_file)
+            if os.path.exists(self.lock.lock_file):
+                os.remove(self.lock.lock_file)
 
 
 class FileSetTarget(Target):

--- a/src/pproc/config/types.py
+++ b/src/pproc/config/types.py
@@ -621,7 +621,7 @@ class ExtremeParamConfig(ClimParamConfig):
     vmin: Optional[float] = None
     vmax: Optional[float] = None
     eps: float = -1.0
-    sot: list[int] = []
+    sot: Union[list[int], list[str]] = []
     cpf_eps: Optional[float] = None
     cpf_symmetric: bool = False
     cpf_from_zero: bool = True
@@ -689,7 +689,11 @@ class ExtremeConfig(BaseConfig):
     def _format_out(self, param: ParamConfig, req: dict) -> dict:
         req = super()._format_out(param, req)
         if req["type"] == "sot":
-            req["number"] = param.sot
+            if isinstance(param.sot[0], str) and param.sot[0].endswith(":100"):
+                sot_key = "quantile"
+            else:
+                sot_key = "number"
+            req[sot_key] = param.sot
         return req
 
     @classmethod

--- a/src/pproc/extremes/__init__.py
+++ b/src/pproc/extremes/__init__.py
@@ -6,4 +6,3 @@
 # In applying this licence, ECMWF does not waive the privileges and immunities
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
-

--- a/src/pproc/extremes/grib.py
+++ b/src/pproc/extremes/grib.py
@@ -66,7 +66,7 @@ def extreme_template(accum, template_fc, template_clim, allow_grib1_to_grib2=Fal
         ]
         grib_keys.update(
             {
-                "productDefinitionTemplateNumber": 105,
+                "productDefinitionTemplateNumber": 107,
                 **{key: template_clim[key] for key in clim_keys},
             }
         )

--- a/src/pproc/extremes/grib.py
+++ b/src/pproc/extremes/grib.py
@@ -178,7 +178,6 @@ def efi_metadata_control(template, metadata) -> dict:
 
 def sot_metadata(template, sot, metadata) -> dict:
     metadata = metadata.copy()
-    metadata["marsType"] = 38
 
     if sot == 90:
         efi_order = 99
@@ -190,6 +189,7 @@ def sot_metadata(template, sot, metadata) -> dict:
         )
     edition = metadata.get("edition", template["edition"])
     if edition == 1:
+        metadata["marsType"] = 38
         metadata["number"] = sot
         metadata["efiOrder"] = efi_order
     elif edition == 2:
@@ -200,6 +200,7 @@ def sot_metadata(template, sot, metadata) -> dict:
                 "numberOfAdditionalParametersForReferencePeriod": 2,
                 "scaleFactorOfAdditionalParameterForReferencePeriod": [0, 0],
                 "scaledValueOfAdditionalParameterForReferencePeriod": [sot, efi_order],
+                "marsType": 38,
             }
         )
     else:

--- a/src/pproc/extremes/grib.py
+++ b/src/pproc/extremes/grib.py
@@ -209,9 +209,9 @@ def sot_metadata(template, sot, metadata) -> dict:
 
 def cpf_metadata(template, metadata) -> dict:
     metadata = metadata.copy()
-    metadata[
-        "marsType"
-    ] = 27  # FIXME: this corresponds to efi, should be a new value for cpf
+    metadata["marsType"] = (
+        27  # FIXME: this corresponds to efi, should be a new value for cpf
+    )
     metadata["bitsPerValue"] = 24
 
     edition = metadata.get("edition", template["edition"])

--- a/src/pproc/extremes/indices.py
+++ b/src/pproc/extremes/indices.py
@@ -82,11 +82,12 @@ class SOT(Index):
     ):
         for perc in self.sot:
             if isinstance(perc, str) and perc.endswith(":100"):
+                # SOT values in GRIB2 are encoded as quantiles 1-10:100, 90-99:100
                 percentiles, _ = perc.split(":")
                 percentiles = list(map(int, percentiles.split("-")))
-                if all([percentiles < 50]):
+                if all(p < 50 for p in percentiles):
                     perc = percentiles[-1]
-                elif all([percentiles > 50]):
+                elif all(p > 50 for p in percentiles):
                     perc = percentiles[0]
                 else:
                     raise ValueError(

--- a/src/pproc/extremes/indices.py
+++ b/src/pproc/extremes/indices.py
@@ -81,6 +81,17 @@ class SOT(Index):
         metadata: dict,
     ):
         for perc in self.sot:
+            if isinstance(perc, str) and perc.endswith(":100"):
+                percentiles, _ = perc.split(":")
+                percentiles = list(map(int, percentiles.split("-")))
+                if all([percentiles < 50]):
+                    perc = percentiles[-1]
+                elif all([percentiles > 50]):
+                    perc = percentiles[0]
+                else:
+                    raise ValueError(
+                        f"Could not determine SOT percentile value from {perc}"
+                    )
             sot = extreme.sot(clim, ens, perc, self.eps)
             sot_keys = sot_metadata(out_template, perc, metadata)
             common.io.write_grib(target, out_template, sot, sot_keys)

--- a/src/pproc/extremes/indices.py
+++ b/src/pproc/extremes/indices.py
@@ -69,7 +69,7 @@ class SOT(Index):
     def __init__(self, options):
         super().__init__(options)
         self.eps = float(options.get("eps", -1.0))
-        self.sot = list(map(int, options.get("sot", [])))
+        self.sot = options.get("sot", [])
 
     def compute(
         self,
@@ -92,6 +92,8 @@ class SOT(Index):
                     raise ValueError(
                         f"Could not determine SOT percentile value from {perc}"
                     )
+            else:
+                perc = int(perc)
             sot = extreme.sot(clim, ens, perc, self.eps)
             sot_keys = sot_metadata(out_template, perc, metadata)
             common.io.write_grib(target, out_template, sot, sot_keys)

--- a/src/pproc/extremes/indices.py
+++ b/src/pproc/extremes/indices.py
@@ -9,6 +9,7 @@
 
 from abc import ABCMeta, abstractmethod
 from typing import Any, Dict
+from functools import cached_property
 
 from earthkit.meteo import extreme
 from eccodes import GRIBMessage
@@ -71,6 +72,25 @@ class SOT(Index):
         self.eps = float(options.get("eps", -1.0))
         self.sot = options.get("sot", [])
 
+    @cached_property
+    def sot_perc(self) -> list[int]:
+        perc = []
+        for p in self.sot:
+            if isinstance(p, str) and p.endswith(":100"):
+                percentiles, _ = p.split(":")
+                percentiles = list(map(int, percentiles.split("-")))
+                if all(p < 50 for p in percentiles):
+                    perc.append(percentiles[-1])
+                elif all(p > 50 for p in percentiles):
+                    perc.append(percentiles[0])
+                else:
+                    raise ValueError(
+                        f"Could not determine SOT percentile value from {p}"
+                    )
+            else:
+                perc.append(int(p))
+        return perc
+
     def compute(
         self,
         clim: np.ndarray,
@@ -80,21 +100,7 @@ class SOT(Index):
         out_template: GRIBMessage,
         metadata: dict,
     ):
-        for perc in self.sot:
-            if isinstance(perc, str) and perc.endswith(":100"):
-                # SOT values in GRIB2 are encoded as quantiles 1-10:100, 90-99:100
-                percentiles, _ = perc.split(":")
-                percentiles = list(map(int, percentiles.split("-")))
-                if all(p < 50 for p in percentiles):
-                    perc = percentiles[-1]
-                elif all(p > 50 for p in percentiles):
-                    perc = percentiles[0]
-                else:
-                    raise ValueError(
-                        f"Could not determine SOT percentile value from {perc}"
-                    )
-            else:
-                perc = int(perc)
+        for perc in self.sot_perc:
             sot = extreme.sot(clim, ens, perc, self.eps)
             sot_keys = sot_metadata(out_template, perc, metadata)
             common.io.write_grib(target, out_template, sot, sot_keys)

--- a/src/pproc/schema/config.py
+++ b/src/pproc/schema/config.py
@@ -28,7 +28,14 @@ class ConfigSchema(BaseSchema):
     def config(self, output_request: dict) -> dict:
         output_request = validate_request(output_request)
         config = self.traverse(output_request)
-        if "quantile" in output_request:
+        if output_request["type"] == "sot":
+            sot_key = "number" if "number" in output_request else "quantile"
+            if sot_key not in output_request:
+                raise ValueError(
+                    f"Output request of type 'sot' must contain either 'number' or 'quantile', but got: {output_request}"
+                )
+            config["sot"] = to_list(output_request[sot_key])
+        elif "quantile" in output_request:
             out_quantiles = to_list(output_request["quantile"])
             numbers = np.zeros(len(out_quantiles))
             totals = np.zeros(len(out_quantiles))
@@ -45,8 +52,6 @@ class ConfigSchema(BaseSchema):
             else:
                 quantiles = list(numbers / totals)
             config["quantiles"] = quantiles
-        if output_request["type"] == "sot":
-            config["sot"] = to_list(output_request["number"])
 
         out_vals = output_request.copy()
         date = str(output_request["date"])

--- a/tests/common/test_accumulation.py
+++ b/tests/common/test_accumulation.py
@@ -526,6 +526,79 @@ def test_grib_header(config, grib_key_values):
     assert header == grib_key_values
 
 
+@pytest.mark.parametrize(
+    "config, dim, expected",
+    [
+        pytest.param(
+            {
+                "coords": [6, 12, 18],
+                "operation": "mean",
+                "metadata": {
+                    "span": "{coords_span}:int",
+                    "increment": "{coords_increment}:int",
+                },
+            },
+            "step",
+            {"stepRange": "6-18", "stepType": "max", "span": 12, "increment": 6},
+            id="step-coords",
+        ),
+        pytest.param(
+            {
+                "coords": ["20240101", "20240103", "20240105"],
+                "metadata": {
+                    "span": "{coords_span}:int",
+                    "start": "{int(start_coord[0:4]) - 20}",
+                    "increment": "{coords_increment}:int",
+                },
+            },
+            "date",
+            {"span": 4, "increment": 2, "start": 2004},
+            id="date-coords",
+        ),
+        pytest.param(
+                    {
+                        "coords": ["20040101", "20060101", "20080101"],
+                        "metadata": {
+                            "span": "{coords_span}:int",
+                            "start": "{int(end_coord[0:4]) - 4}",
+                            "increment": "{coords_increment}:int",
+                        },
+                    },
+                    "hdate",
+                    {"span": 4, "increment": 2, "start": 2004},
+                    id="hdate-coords",
+                ),
+        pytest.param(
+            {
+                "coords": ["0-168"],
+                "metadata": {
+                    "span": "{coords_span}:int",
+                    "increment": "{coords_increment}:int",
+                },
+            },
+            "step",
+            {"stepRange": "0-168", "span": 168, "increment": 0},
+            id="precomputed-coords",
+        ),
+        pytest.param(
+            {
+                "coords": ["x", "y"],
+                "metadata": {
+                    "span": "{coords_span}",
+                    "increment": "{coords_increment}",
+                },
+            },
+            "dim",
+            {"span": None, "increment": None},
+            id="non-numeric-coords",
+        ),
+    ],
+)
+def test_grib_header_coords(config, dim, expected):
+    accum = create_accumulation(config)
+    assert accum.grib_keys(dim) == expected
+
+
 def test_accumulator_contains():
     assert {"step": 12} in Accumulator({"step": Mean(range(6, 24, 6))})
     assert {"hdate": 20200301, "step": 6, "example": "a"} in Accumulator(

--- a/tests/common/test_accumulation.py
+++ b/tests/common/test_accumulation.py
@@ -534,8 +534,8 @@ def test_grib_header(config, grib_key_values):
                 "coords": [6, 12, 18],
                 "operation": "mean",
                 "metadata": {
-                    "span": "{coords_span}:int",
-                    "increment": "{coords_increment}:int",
+                    "span": "{coords_span}",
+                    "increment": "{coords_increment}",
                 },
             },
             "step",
@@ -546,9 +546,9 @@ def test_grib_header(config, grib_key_values):
             {
                 "coords": ["20240101", "20240103", "20240105"],
                 "metadata": {
-                    "span": "{coords_span}:int",
+                    "span": "{coords_span}",
                     "start": "{int(start_coord[0:4]) - 20}",
-                    "increment": "{coords_increment}:int",
+                    "increment": "{coords_increment}",
                 },
             },
             "date",
@@ -556,12 +556,24 @@ def test_grib_header(config, grib_key_values):
             id="date-coords",
         ),
         pytest.param(
+            {
+                "coords": [20240101, 20240103, 20240105],
+                "metadata": {
+                    "span": "{coords_span}",
+                    "increment": "{coords_increment}",
+                },
+            },
+            "date",
+            {"span": 4, "increment": 2},
+            id="date-coords-int",
+        ),
+        pytest.param(
                     {
                         "coords": ["20040101", "20060101", "20080101"],
                         "metadata": {
-                            "span": "{coords_span}:int",
+                            "span": "{coords_span}",
                             "start": "{int(end_coord[0:4]) - 4}",
-                            "increment": "{coords_increment}:int",
+                            "increment": "{coords_increment}",
                         },
                     },
                     "hdate",
@@ -572,8 +584,8 @@ def test_grib_header(config, grib_key_values):
             {
                 "coords": ["0-168"],
                 "metadata": {
-                    "span": "{coords_span}:int",
-                    "increment": "{coords_increment}:int",
+                    "span": "{coords_span}",
+                    "increment": "{coords_increment}",
                 },
             },
             "step",

--- a/tests/common/test_grib_helpers.py
+++ b/tests/common/test_grib_helpers.py
@@ -1,0 +1,32 @@
+# (C) Copyright 2021- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+import pytest
+
+from pproc.common.grib_helpers import fill_template_value
+
+
+@pytest.mark.parametrize(
+    "value, template_map, expected",
+    [
+        ("{start_coord}", {"start_coord": "20240507"}, "20240507"),
+        ("{coords_span}:int", {"coords_span": 24}, 24),
+        ("{start_coord[0:6]}", {"start_coord": "20240507"}, "202405"),
+        ("{int(start_coord[0:6])}", {"start_coord": "20240507"}, 202405),
+        ("{int(start_coord[0:4]) - 20}", {"start_coord": "20240507"}, 2004),
+        (
+            "clim_{start_coord[0:4]}",
+            {"start_coord": "20240507"},
+            "clim_{start_coord[0:4]}",
+        ),
+    ],
+    ids=["no-type", "typed-int", "slice-str", "slice-int", "slice-expression", "noop"],
+)
+def test_fill_template_value(value, template_map, expected):
+    assert fill_template_value(value, template_map) == expected

--- a/tests/common/test_grib_helpers.py
+++ b/tests/common/test_grib_helpers.py
@@ -25,8 +25,13 @@ from pproc.common.grib_helpers import fill_template_value
             {"start_coord": "20240507"},
             "clim_{start_coord[0:4]}",
         ),
+        (
+            "{start_coord[0:4]}",
+            {"end_coord": "20240507"},
+            "{start_coord[0:4]}",
+        ),
     ],
-    ids=["no-type", "typed-int", "slice-str", "slice-int", "slice-expression", "noop"],
+    ids=["no-type", "typed-int", "slice-str", "slice-int", "slice-expression", "noop", "missing-key"],
 )
 def test_fill_template_value(value, template_map, expected):
     assert fill_template_value(value, template_map) == expected


### PR DESCRIPTION
### Description
- Support for change from SOT `number=[10, 90]` values in GRIB2 to `quantile=1-[10:100, 90-99:100]`
- Expand keys derivable from accumulations to include span and increment
- Expand filling of metadata keys from templates to allow basic arithmetic, for setting of mclimate keys
- Support for filelock > 3.32

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
