### PR TITLE
XarrayTarget with (optional) NetCDF writing/recovery

### DIFF
--- a/src/pproc/common/xr_helpers.py
+++ b/src/pproc/common/xr_helpers.py
@@ -26,7 +26,10 @@ class DatasetBuilder:
         self._committed = manager.list(self._committed)
 
     def stage(self, ds):
+        if isinstance(ds, xr.DataArray) and ds.name is None:
+            raise ValueError("DataArrays must have a name")
         self._staged.append(ds)
+        return self
 
     def commit(self):
         if not self._staged:
@@ -34,9 +37,11 @@ class DatasetBuilder:
         ds_staged = xr.combine_by_coords(self._staged, **self._combine_kwargs)
         self._committed.append(ds_staged.load())  # force computation of values
         self.reset_staged()
+        return self
 
     def reset_staged(self):
         self._staged.clear()
+        return self
 
     def undo_commit(self, *, stage=False):
         if not self._committed:
@@ -44,9 +49,11 @@ class DatasetBuilder:
         removed = self._committed.pop()
         if stage:
             self.stage(removed)
+        return self
 
     def squash_commits(self):
         self._committed[:] = [self.to_dataset()]
+        return self
 
     def to_dataset(self) -> xr.Dataset:
         if not self._committed:

--- a/src/pproc/common/xr_helpers.py
+++ b/src/pproc/common/xr_helpers.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+# SPDX-License-Identifier: Apache-2.0
+
+import functools
+
+import xarray as xr
+
+
+class DatasetBuilder:
+    """Transactional xarray.Dataset builder.
+
+    Collects Datasets and DataArrays in a staging area. When the staged contents
+    form a proper datacube, they can be committed. The final dataset is created
+    by outer-joining all committed cubes.
+    """
+
+    def __init__(self, combine_kwargs=None):
+        self._staged: list[xr.DataArray | xr.Dataset] = []
+        self._committed: list[xr.Dataset] = []  # oldest first
+        if combine_kwargs is None:
+            combine_kwargs = {}
+        combine_kwargs["join"] = "exact"  # always enforce full datacubes
+        self._combine_kwargs = combine_kwargs
+
+    def enable_parallel(self, manager):
+        self._committed = manager.list(self._committed)
+
+    def stage(self, ds):
+        self._staged.append(ds)
+
+    def commit(self):
+        if not self._staged:
+            return
+        ds_staged = xr.combine_by_coords(self._staged, **self._combine_kwargs)
+        self._committed.append(ds_staged.load())  # force computation of values
+        self.reset_staged()
+
+    def reset_staged(self):
+        self._staged.clear()
+
+    def undo_commit(self, *, stage=False):
+        if not self._committed:
+            raise RuntimeError("no commits to undo")
+        removed = self._committed.pop()
+        if stage:
+            self.stage(removed)
+
+    def squash_commits(self):
+        self._committed[:] = [self.to_dataset()]
+
+    def to_dataset(self) -> xr.Dataset:
+        if not self._committed:
+            return xr.Dataset()
+        # Merge wth later commits overriding earlier ones
+        return functools.reduce(
+            lambda newer, older: newer.combine_first(older),
+            reversed(self._committed),
+        )

--- a/src/pproc/config/io.py
+++ b/src/pproc/config/io.py
@@ -31,6 +31,7 @@ from pproc.config.targets import (
     FileTarget,
     NullTarget,
     OverrideTargetWrapper,
+    XarrayTarget,
 )
 from pproc.extremes.indices import SUPPORTED_INDICES
 
@@ -157,6 +158,7 @@ class Output(ConfigModel):
             Annotated[FileSetTarget, Tag("fileset")],
             Annotated[FDBTarget, Tag("fdb")],
             Annotated[OverrideTargetWrapper, Tag("override")],
+            Annotated[XarrayTarget, Tag("xarray")],
         ],
         Discriminator(target_discriminator),
         Field(default_factory=NullTarget),

--- a/src/pproc/config/io.py
+++ b/src/pproc/config/io.py
@@ -31,7 +31,7 @@ from pproc.config.targets import (
     FileTarget,
     NullTarget,
     OverrideTargetWrapper,
-    XarrayTarget,
+    NetCDFTarget,
 )
 from pproc.extremes.indices import SUPPORTED_INDICES
 
@@ -158,7 +158,7 @@ class Output(ConfigModel):
             Annotated[FileSetTarget, Tag("fileset")],
             Annotated[FDBTarget, Tag("fdb")],
             Annotated[OverrideTargetWrapper, Tag("override")],
-            Annotated[XarrayTarget, Tag("xarray")],
+            Annotated[NetCDFTarget, Tag("netcdf")],
         ],
         Discriminator(target_discriminator),
         Field(default_factory=NullTarget),

--- a/src/pproc/config/targets.py
+++ b/src/pproc/config/targets.py
@@ -244,7 +244,7 @@ class NetCDFTarget(Target):
         with self.lock:
             self._builder.commit()
             ds_out = self.to_dataset()
-            if not ds_out:
+            if not ds_out.data_vars:
                 return
             try:
                 ds_out.to_netcdf(self._tmp_path)

--- a/src/pproc/config/targets.py
+++ b/src/pproc/config/targets.py
@@ -7,6 +7,7 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
+import functools
 import multiprocessing
 import os
 from typing import Any, Literal, Optional, Union
@@ -14,7 +15,9 @@ from typing_extensions import Self
 import yaml
 
 import eccodes
+import numpy as np
 import pyfdb
+import xarray as xr
 from annotated_types import Annotated
 from conflator import ConfigModel
 from filelock import FileLock
@@ -200,3 +203,104 @@ class OverrideTargetWrapper(ConfigModel, Target):
 
     def clean(self):
         return self.wrapped.clean()
+
+
+class CombineKwargs(BaseModel):
+    """Arguments for :func:`xarray.combine_by_coords`."""
+
+    model_config = ConfigDict(extra="forbid")  # join and fill value set by XarrayTarget
+
+    compat: str = "no_conflicts"
+    data_vars: str = "all"
+    coords: str = "minimal"
+    combine_attrs: str = "drop_conflicts"
+
+
+class XarrayTarget(Target):
+    """Transactional xarray.Dataset builder with (optional) flushing to disk.
+
+    DataArrays are staged in the local process until flushed. Only complete
+    datacubes can be flushed (to ensure safe merging).
+
+    Formats:
+    - "netcdf" (replaces file on every flush)
+    - "memory" (only collects in memory, writing is left to entrypoint)
+    """
+
+    type_: Literal["xarray"] = Field("xarray", alias="type")
+    path: str | None = None
+    format: Literal["netcdf", "memory"] = "netcdf"
+    clean_lock: bool = True
+    combine_kwargs: CombineKwargs = CombineKwargs()
+
+    _staged: list[xr.DataArray] = []
+    _committed: list[xr.Dataset] = []  # oldest first
+
+    @model_validator(mode="after")
+    def validate_path(self):
+        if self.format != "memory" and self.path is None:
+            raise ValueError(f"path is required for format {self.format}")
+        return self
+
+    @property
+    def lock(self) -> FileLock:
+        return FileLock(self.path + ".lock", thread_local=False)
+
+    @property
+    def _tmp_path(self) -> str:
+        return self.path + ".tmp"
+
+    def flush(self):
+        """Commit everything written/staged since the last flush."""
+        if not self._staged:
+            return
+        ds_staged = xr.combine_by_coords(
+            self._staged,
+            join="exact",  # enforce full datacubes
+            fill_value=np.nan,
+            **self.combine_kwargs.model_dump(),
+        ).load()  # force computation of values
+        if self.format == "memory":
+            self._committed.append(ds_staged)
+        elif self.format == "netcdf":
+            with self.lock:
+                ds_out = self._consolidate([*self._committed, ds_staged])
+                ds_out.to_netcdf(self._tmp_path)
+                os.replace(self._tmp_path, self.path)
+                # Replace collected parts with consolidated dataset while lock is aquired
+                self._committed[:] = [ds_out]
+        else:
+            raise NotImplementedError(f"format {self.format}")
+        self._staged.clear()
+
+    def write(self, ds):
+        self._staged.append(ds)
+
+    def enable_recovery(self):
+        if self.format == "memory":
+            raise NotImplementedError("Recovery is not supported with format memory")
+        if os.path.exists(self.path):
+            self._committed.append(xr.load_dataset(self.path))
+
+    def enable_parallel(self):
+        self._committed = _shared_list()
+
+    def clean(self):
+        if self.path is None:
+            return
+        if os.path.exists(self._tmp_path):
+            os.remove(self._tmp_path)
+        if self.clean_lock and os.path.exists(self.lock.lock_file):
+            os.remove(self.lock.lock_file)
+
+    @staticmethod
+    def _consolidate(generations: list[xr.Dataset]) -> xr.Dataset:
+        """Merge generations given oldest first, later ones overriding earlier ones."""
+        if not generations:
+            return xr.Dataset()
+        return functools.reduce(
+            lambda newer, older: newer.combine_first(older), reversed(generations)
+        )
+
+    def as_dataset(self) -> xr.Dataset:
+        return self._consolidate(list(self._committed))

--- a/src/pproc/config/targets.py
+++ b/src/pproc/config/targets.py
@@ -7,7 +7,6 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-import functools
 import multiprocessing
 import os
 from typing import Any, Literal, Optional, Union
@@ -24,6 +23,7 @@ from filelock import FileLock
 from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, model_validator
 
 from pproc.config import utils
+from pproc.common.xr_helpers import DatasetBuilder
 
 _manager = None
 
@@ -216,30 +216,17 @@ class CombineKwargs(BaseModel):
     combine_attrs: str = "drop_conflicts"
 
 
-class XarrayTarget(Target):
-    """Transactional xarray.Dataset builder with (optional) flushing to disk.
-
-    DataArrays are staged in the local process until flushed. Only complete
-    datacubes can be flushed (to ensure safe merging).
-
-    Formats:
-    - "netcdf" (replaces file on every flush)
-    - "memory" (only collects in memory, writing is left to entrypoint)
-    """
-
-    type_: Literal["xarray"] = Field("xarray", alias="type")
-    path: str | None = None
-    format: Literal["netcdf", "memory"] = "netcdf"
+class NetCDFTarget(Target):
+    type_: Literal["netcdf"] = Field("netcdf", alias="type")
+    path: str
     clean_lock: bool = True
     combine_kwargs: CombineKwargs = CombineKwargs()
 
-    _staged: list[xr.DataArray] = []
-    _committed: list[xr.Dataset] = []  # oldest first
+    _builder: DatasetBuilder
 
     @model_validator(mode="after")
-    def validate_path(self):
-        if self.format != "memory" and self.path is None:
-            raise ValueError(f"path is required for format {self.format}")
+    def validate_builder(self):
+        self._builder = DatasetBuilder(combine_kwargs=self.combine_kwargs.model_dump())
         return self
 
     @property
@@ -250,57 +237,39 @@ class XarrayTarget(Target):
     def _tmp_path(self) -> str:
         return self.path + ".tmp"
 
+    def write(self, ds):
+        self._builder.stage(ds)
+
     def flush(self):
-        """Commit everything written/staged since the last flush."""
-        if not self._staged:
-            return
-        ds_staged = xr.combine_by_coords(
-            self._staged,
-            join="exact",  # enforce full datacubes
-            fill_value=np.nan,
-            **self.combine_kwargs.model_dump(),
-        ).load()  # force computation of values
-        if self.format == "memory":
-            self._committed.append(ds_staged)
-        elif self.format == "netcdf":
-            with self.lock:
-                ds_out = self._consolidate([*self._committed, ds_staged])
+        with self.lock:
+            self._builder.commit()
+            ds_out = self.to_dataset()
+            if not ds_out:
+                return
+            try:
                 ds_out.to_netcdf(self._tmp_path)
                 os.replace(self._tmp_path, self.path)
-                # Replace collected parts with consolidated dataset while lock is aquired
-                self._committed[:] = [ds_out]
-        else:
-            raise NotImplementedError(f"format {self.format}")
-        self._staged.clear()
-
-    def write(self, ds):
-        self._staged.append(ds)
-
-    def enable_recovery(self):
-        if self.format == "memory":
-            raise NotImplementedError("Recovery is not supported with format memory")
-        if os.path.exists(self.path):
-            self._committed.append(xr.load_dataset(self.path))
+            except:
+                # The file was not replaced. (Soft-)revert the last commit
+                # while the lock is aquired to synchronise the committed
+                # state of the builder with the actual file content
+                self._builder.undo_commit(stage=True)
+                raise
 
     def enable_parallel(self):
-        self._committed = _shared_list()
+        # TODO find something better than messing with a builder internal
+        self._builder._committed = _shared_list()
+
+    def enable_recovery(self):
+        if os.path.exists(self.path):
+            self._builder.stage(xr.load_dataset(self.path))
+            self._builder.commit()
 
     def clean(self):
-        if self.path is None:
-            return
         if os.path.exists(self._tmp_path):
             os.remove(self._tmp_path)
         if self.clean_lock and os.path.exists(self.lock.lock_file):
             os.remove(self.lock.lock_file)
 
-    @staticmethod
-    def _consolidate(generations: list[xr.Dataset]) -> xr.Dataset:
-        """Merge generations given oldest first, later ones overriding earlier ones."""
-        if not generations:
-            return xr.Dataset()
-        return functools.reduce(
-            lambda newer, older: newer.combine_first(older), reversed(generations)
-        )
-
-    def as_dataset(self) -> xr.Dataset:
-        return self._consolidate(list(self._committed))
+    def to_dataset(self):
+        return self._builder.to_dataset()

--- a/tests/common/test_xr_helpers.py
+++ b/tests/common/test_xr_helpers.py
@@ -48,6 +48,10 @@ class TestDatasetBuilder:
         builder.stage(make_da())
         xr.testing.assert_identical(builder.to_dataset(), xr.Dataset())
 
+    def test_stage_rejects_unnamed_dataarray(self, builder):
+        with pytest.raises(ValueError):
+            builder.stage(make_da(name=None))
+
     def test_commit_without_stages(self, builder):
         builder.commit()
         xr.testing.assert_identical(builder.to_dataset(), xr.Dataset())

--- a/tests/common/test_xr_helpers.py
+++ b/tests/common/test_xr_helpers.py
@@ -1,0 +1,159 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+# SPDX-License-Identifier: Apache-2.0
+
+import multiprocessing
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from pproc.common import parallel
+from pproc.common.xr_helpers import DatasetBuilder
+
+
+def make_da(name="foo", lons=(0.0, 10.0, 20.0), region=None, val=None):
+    values = np.arange(len(lons), dtype=float) + 1.0
+    if val is not None:
+        values = np.full(len(lons), float(val))
+    da = xr.DataArray(values, coords={"lon": list(lons)}, dims=["lon"], name=name)
+    if region is not None:
+        da = da.expand_dims({"region": [region]})
+    return da
+
+
+def make_da_blocks(**kwargs):
+    return [
+        make_da(lons=(0.0, 10.0, 20.0), region="nh", **kwargs),
+        make_da(lons=(30.0, 40.0, 50.0), region="nh", **kwargs),
+        make_da(lons=(0.0, 10.0, 20.0), region="sh", **kwargs, val=1.0),
+        make_da(lons=(30.0, 40.0, 50.0), region="sh", **kwargs, val=2.0),
+    ]
+
+
+def commit(target, dataarrays):
+    for da in dataarrays:
+        target.stage(da)
+    target.commit()
+
+
+class TestDatasetBuilder:
+    @pytest.fixture
+    def builder(self):
+        return DatasetBuilder()
+
+    def test_to_dataset_without_commits(self, builder):
+        xr.testing.assert_identical(builder.to_dataset(), xr.Dataset())
+
+    def test_stage_does_not_commit(self, builder):
+        builder.stage(make_da())
+        xr.testing.assert_identical(builder.to_dataset(), xr.Dataset())
+
+    def test_commit_without_stages(self, builder):
+        builder.commit()
+        xr.testing.assert_identical(builder.to_dataset(), xr.Dataset())
+
+    def test_commit_rejects_variables_covering_different_blocks(self, builder):
+        builder.stage(make_da("foo"))
+        builder.stage(make_da("foo", lons=(30.0, 40.0, 50.0)))
+        builder.stage(make_da("bar"))
+        with pytest.raises(ValueError):
+            builder.commit()
+        xr.testing.assert_identical(builder.to_dataset(), xr.Dataset())
+
+    def test_commit_rejects_sparse_cube(self, builder):
+        a, b, c, d = make_da_blocks()
+        builder.stage(a)
+        builder.stage(b)
+        builder.stage(d)
+        with pytest.raises(ValueError):
+            builder.commit()
+        xr.testing.assert_identical(builder.to_dataset(), xr.Dataset())
+        builder.stage(c)  # complete the cube to allow commiting
+        builder.commit()
+        expected = xr.combine_by_coords([a, b, c, d])
+        xr.testing.assert_identical(builder.to_dataset(), expected)
+
+    def test_commit_rejects_duplicates(self, builder):
+        builder.stage(make_da())
+        builder.stage(make_da())
+        with pytest.raises(ValueError):
+            builder.commit()
+        xr.testing.assert_identical(builder.to_dataset(), xr.Dataset())
+
+    def test_to_dataset_one_dataarray(self, builder):
+        da = make_da()
+        commit(builder, [da])
+        xr.testing.assert_identical(builder.to_dataset(), da.to_dataset())
+
+    def test_to_dataset_two_blocks(self, builder):
+        first, second, _, _ = make_da_blocks()
+        commit(builder, [first, second])
+        xr.testing.assert_identical(
+            builder.to_dataset(), xr.concat([first, second], dim="lon").to_dataset()
+        )
+
+    def test_to_dataset_two_variables(self, builder):
+        foo, bar = make_da("foo"), make_da("bar")
+        commit(builder, [foo, bar])
+        result = builder.to_dataset()
+        assert list(result.data_vars) == ["foo", "bar"]
+        xr.testing.assert_identical(result, xr.merge([foo, bar]))
+
+    def test_to_dataset_two_variables_two_blocks(self, builder):
+        a, b, _, _ = make_da_blocks()
+        c = a.rename("bar")
+        d = b.rename("bar")
+        commit(builder, [a, c, b, d])  # interleaved, to cover out-of-order arrival
+        expected = xr.combine_by_coords([a, b, c, d])
+        xr.testing.assert_identical(builder.to_dataset(), expected)
+
+    def test_to_dataset_two_variables_one_with_extra_dim(self, builder):
+        foo = make_da(name="foo", region=None)
+        bar_nh = make_da(name="bar", region="nh")
+        bar_sh = make_da(name="bar", region="sh")
+        commit(builder, [foo, bar_nh, bar_sh])
+        expected = xr.combine_by_coords([foo, bar_nh, bar_sh])
+        xr.testing.assert_identical(builder.to_dataset(), expected)
+
+    def test_to_dataset_is_repeatable(self, builder):
+        a, b, c, d = make_da_blocks()
+        commit(builder, [a, b])
+        # Reading twice yields the same dataset
+        xr.testing.assert_identical(builder.to_dataset(), builder.to_dataset())
+        # Reading doesn't affect subsequent commits
+        commit(builder, [c, d])
+        expected = xr.combine_by_coords([a, b, c, d])
+        xr.testing.assert_identical(builder.to_dataset(), expected)
+
+    def test_later_commit_overrides_earlier(self, builder):
+        commit(builder, [make_da(region="nh", val=1.0), make_da(region="sh", val=1.0)])
+        commit(builder, [make_da(region="nh", val=9.0)])
+        expected = xr.concat(
+            [make_da(region="nh", val=9.0), make_da(region="sh", val=1.0)], dim="region"
+        ).to_dataset()
+        xr.testing.assert_identical(builder.to_dataset(), expected)
+
+    def test_commits_may_form_a_sparse_cube(self, builder):
+        a, b, c, _ = make_da_blocks()
+        # Each commit is a cube on its own, the union of the two is not
+        commit(builder, [b])
+        commit(builder, [a, c])
+        expected = xr.combine_by_coords([a, b, c], join="outer", fill_value=np.nan)
+        xr.testing.assert_identical(builder.to_dataset(), expected)
+
+    def test_commits_may_stage_a_variable(self, builder):
+        commit(builder, [make_da("foo")])
+        commit(builder, [make_da("bar")])
+        assert sorted(builder.to_dataset().data_vars) == ["bar", "foo"]
+
+    def test_parallel_commits_reach_the_parent(self, builder):
+        manager = multiprocessing.Manager()
+        builder.enable_parallel(manager)
+        blocks = make_da_blocks()
+        parallel.parallel_processing(
+            commit,
+            [(builder, [block]) for block in blocks],
+            2,
+        )
+        expected = xr.combine_by_coords(blocks)
+        xr.testing.assert_identical(expected, builder.to_dataset())

--- a/tests/config/test_targets.py
+++ b/tests/config/test_targets.py
@@ -10,7 +10,7 @@ import pytest
 import xarray as xr
 
 from pproc.common import parallel
-from pproc.config.targets import XarrayTarget
+from pproc.config.targets import NetCDFTarget
 
 
 def make_da(name="foo", lons=(0.0, 10.0, 20.0), region=None, val=None):
@@ -39,151 +39,10 @@ def commit(target, dataarrays):
     target.flush()
 
 
-class XarrayTargetContract:
-    """Behaviour shared by all formats, observed through as_dataset()."""
-
-    def test_as_dataset_without_commits(self, target):
-        xr.testing.assert_identical(target.as_dataset(), xr.Dataset())
-
-    def test_write_does_not_commit(self, target):
-        target.write(make_da())
-        xr.testing.assert_identical(target.as_dataset(), xr.Dataset())
-
-    def test_flush_without_writes(self, target):
-        target.flush()
-        xr.testing.assert_identical(target.as_dataset(), xr.Dataset())
-
-    def test_flush_rejects_variables_covering_different_blocks(self, target):
-        target.write(make_da("foo"))
-        target.write(make_da("foo", lons=(30.0, 40.0, 50.0)))
-        target.write(make_da("bar"))
-        with pytest.raises(ValueError):
-            target.flush()
-        xr.testing.assert_identical(target.as_dataset(), xr.Dataset())
-
-    def test_flush_rejects_sparse_cube(self, target):
-        a, b, c, d = make_da_blocks()
-        target.write(a)
-        target.write(b)
-        target.write(d)
-        with pytest.raises(ValueError):
-            target.flush()
-        xr.testing.assert_identical(target.as_dataset(), xr.Dataset())
-        target.write(c)  # complete the cube to allow flushing
-        target.flush()
-        expected = xr.combine_by_coords([a, b, c, d])
-        xr.testing.assert_identical(target.as_dataset(), expected)
-
-    def test_flush_rejects_duplicates(self, target):
-        target.write(make_da())
-        target.write(make_da())
-        with pytest.raises(ValueError):
-            target.flush()
-        xr.testing.assert_identical(target.as_dataset(), xr.Dataset())
-
-    def test_as_dataset_one_dataarray(self, target):
-        da = make_da()
-        commit(target, [da])
-        xr.testing.assert_identical(target.as_dataset(), da.to_dataset())
-
-    def test_as_dataset_two_blocks(self, target):
-        first, second, _, _ = make_da_blocks()
-        commit(target, [first, second])
-        xr.testing.assert_identical(
-            target.as_dataset(), xr.concat([first, second], dim="lon").to_dataset()
-        )
-
-    def test_as_dataset_two_variables(self, target):
-        foo, bar = make_da("foo"), make_da("bar")
-        commit(target, [foo, bar])
-        result = target.as_dataset()
-        assert list(result.data_vars) == ["foo", "bar"]
-        xr.testing.assert_identical(result, xr.merge([foo, bar]))
-
-    def test_as_dataset_two_variables_two_blocks(self, target):
-        a, b, _, _ = make_da_blocks()
-        c = a.rename("bar")
-        d = b.rename("bar")
-        commit(target, [a, c, b, d])  # interleaved, to cover out-of-order arrival
-        expected = xr.combine_by_coords([a, b, c, d])
-        xr.testing.assert_identical(target.as_dataset(), expected)
-
-    def test_as_dataset_two_variables_one_with_extra_dim(self, target):
-        foo = make_da(name="foo", region=None)
-        bar_nh = make_da(name="bar", region="nh")
-        bar_sh = make_da(name="bar", region="sh")
-        commit(target, [foo, bar_nh, bar_sh])
-        expected = xr.combine_by_coords([foo, bar_nh, bar_sh])
-        xr.testing.assert_identical(target.as_dataset(), expected)
-
-    def test_as_dataset_is_repeatable(self, target):
-        a, b, c, d = make_da_blocks()
-        commit(target, [a, b])
-        # Reading twice yields the same dataset
-        xr.testing.assert_identical(target.as_dataset(), target.as_dataset())
-        # Reading doesn't affect subsequent commits
-        commit(target, [c, d])
-        expected = xr.combine_by_coords([a, b, c, d])
-        xr.testing.assert_identical(target.as_dataset(), expected)
-
-    def test_later_commit_overrides_earlier(self, target):
-        commit(target, [make_da(region="nh", val=1.0), make_da(region="sh", val=1.0)])
-        commit(target, [make_da(region="nh", val=9.0)])
-        expected = xr.concat(
-            [make_da(region="nh", val=9.0), make_da(region="sh", val=1.0)], dim="region"
-        ).to_dataset()
-        xr.testing.assert_identical(target.as_dataset(), expected)
-
-    def test_commits_may_form_a_sparse_cube(self, target):
-        a, b, c, _ = make_da_blocks()
-        # Each commit is a cube on its own, the union of the two is not
-        commit(target, [b])
-        commit(target, [a, c])
-        expected = xr.combine_by_coords([a, b, c], join="outer", fill_value=np.nan)
-        xr.testing.assert_identical(target.as_dataset(), expected)
-
-    def test_commits_may_add_a_variable(self, target):
-        commit(target, [make_da("foo")])
-        commit(target, [make_da("bar")])
-        assert sorted(target.as_dataset().data_vars) == ["bar", "foo"]
-
-
-class TestXarrayTargetMemory(XarrayTargetContract):
-    @pytest.fixture
-    def target(self):
-        return XarrayTarget(format="memory")
-
-    def test_a_path_is_kept_but_not_written_to(self, tmpdir):
-        # The destination may be carried for a later write-out phase
-        target = XarrayTarget(format="memory", path=str(tmpdir / "test.nc"))
-        commit(target, [make_da()])
-        assert target.path == str(tmpdir / "test.nc")
-        assert os.listdir(str(tmpdir)) == []
-
-    def test_parallel_commits_reach_the_parent(self, target):
-        target.enable_parallel()
-        blocks = make_da_blocks()
-        parallel.parallel_processing(
-            commit,
-            [(target, [block]) for block in blocks],
-            2,
-        )
-        expected = xr.combine_by_coords(blocks)
-        xr.testing.assert_identical(expected, target.as_dataset())
-
-    def test_recovery_is_not_supported(self, target):
-        with pytest.raises(NotImplementedError):
-            target.enable_recovery()
-
-
-class TestXarrayTargetNetCDF(XarrayTargetContract):
+class TestNetCDFTarget:
     @pytest.fixture
     def target(self, tmpdir):
-        return XarrayTarget(path=str(tmpdir / "test.nc"), format="netcdf")
-
-    def test_path_is_required(self):
-        with pytest.raises(pydantic.ValidationError):
-            XarrayTarget(format="netcdf")
+        return NetCDFTarget(path=str(tmpdir / "test.nc"))
 
     def test_nothing_is_written_without_a_commit(self, target):
         target.flush()  # nothing staged
@@ -196,8 +55,8 @@ class TestXarrayTargetNetCDF(XarrayTargetContract):
         assert not os.path.exists(target.path)
 
     def test_targets_do_not_share_writes(self, tmpdir):
-        first = XarrayTarget(path=str(tmpdir / "first.nc"), format="netcdf")
-        second = XarrayTarget(path=str(tmpdir / "second.nc"), format="netcdf")
+        first = NetCDFTarget(path=str(tmpdir / "first.nc"), format="netcdf")
+        second = NetCDFTarget(path=str(tmpdir / "second.nc"), format="netcdf")
         commit(first, [make_da("foo")])
         commit(second, [make_da("bar")])
         xr.testing.assert_identical(
@@ -233,7 +92,7 @@ class TestXarrayTargetNetCDF(XarrayTargetContract):
 
         xr.testing.assert_identical(xr.load_dataset(target.path), committed)
         # The object does not claim more than is on disk
-        xr.testing.assert_identical(target.as_dataset(), xr.load_dataset(target.path))
+        xr.testing.assert_identical(target.to_dataset(), xr.load_dataset(target.path))
 
     def test_flush_can_be_retried_after_a_failure(self, target):
         da = make_da(region="nh", val=1.0)
@@ -274,23 +133,23 @@ class TestXarrayTargetNetCDF(XarrayTargetContract):
 
     def test_recovery_without_existing_file(self, target):
         target.enable_recovery()
-        xr.testing.assert_identical(target.as_dataset(), xr.Dataset())
+        xr.testing.assert_identical(target.to_dataset(), xr.Dataset())
 
     def test_recovery_loads_existing_file(self, target):
         da = make_da()
         commit(target, [da])
         assert os.path.isfile(target.path)
-        resumed = XarrayTarget(
+        resumed = NetCDFTarget(
             path=target.path, format="netcdf"
         )  # as a resumed run would create
         resumed.enable_recovery()
-        xr.testing.assert_identical(resumed.as_dataset(), da.to_dataset())
+        xr.testing.assert_identical(resumed.to_dataset(), da.to_dataset())
 
     def test_a_fresh_run_overwrites_an_existing_file(self, target):
         # Recovery is opt-in, so without it the previous results are replaced
         commit(target, [make_da(region="nh", val=1.0)])
         assert os.path.isfile(target.path)
-        fresh = XarrayTarget(path=target.path, format="netcdf")
+        fresh = NetCDFTarget(path=target.path, format="netcdf")
         commit(fresh, [make_da(region="sh", val=2.0)])
         xr.testing.assert_identical(
             xr.load_dataset(fresh.path), make_da(region="sh", val=2.0).to_dataset()
@@ -300,13 +159,13 @@ class TestXarrayTargetNetCDF(XarrayTargetContract):
         a, b, c, d = make_da_blocks()
         a99 = a.copy(data=np.full_like(a.data, fill_value=99.0))
         commit(target, [a, c])
-        resumed = XarrayTarget(path=target.path, format="netcdf")
+        resumed = NetCDFTarget(path=target.path, format="netcdf")
         resumed.enable_recovery()
         # nh is recomputed, and a block that was never reached is added
         commit(resumed, [a99])  # "recomputed"
         commit(resumed, [b, d])  # new block
         expected = xr.combine_by_coords([a99, b, c, d])
-        xr.testing.assert_identical(resumed.as_dataset(), expected)
+        xr.testing.assert_identical(resumed.to_dataset(), expected)
         xr.testing.assert_identical(xr.load_dataset(resumed.path), expected)
 
     def test_recovery_after_an_interrupted_commit(self, target):
@@ -319,6 +178,6 @@ class TestXarrayTargetNetCDF(XarrayTargetContract):
             with pytest.raises(OSError):
                 target.flush()
 
-        resumed = XarrayTarget(path=target.path)
+        resumed = NetCDFTarget(path=target.path)
         resumed.enable_recovery()
-        xr.testing.assert_identical(resumed.as_dataset(), a.to_dataset())
+        xr.testing.assert_identical(resumed.to_dataset(), a.to_dataset())

--- a/tests/config/test_targets.py
+++ b/tests/config/test_targets.py
@@ -1,0 +1,324 @@
+# SPDX-FileCopyrightText: 2026 European Centre for Medium-Range Weather Forecasts (ECMWF)
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+from unittest.mock import patch
+
+import numpy as np
+import pydantic
+import pytest
+import xarray as xr
+
+from pproc.common import parallel
+from pproc.config.targets import XarrayTarget
+
+
+def make_da(name="foo", lons=(0.0, 10.0, 20.0), region=None, val=None):
+    values = np.arange(len(lons), dtype=float) + 1.0
+    if val is not None:
+        values = np.full(len(lons), float(val))
+    da = xr.DataArray(values, coords={"lon": list(lons)}, dims=["lon"], name=name)
+    if region is not None:
+        da = da.expand_dims({"region": [region]})
+    return da
+
+
+def make_da_blocks(**kwargs):
+    return [
+        make_da(lons=(0.0, 10.0, 20.0), region="nh", **kwargs),
+        make_da(lons=(30.0, 40.0, 50.0), region="nh", **kwargs),
+        make_da(lons=(0.0, 10.0, 20.0), region="sh", **kwargs, val=1.0),
+        make_da(lons=(30.0, 40.0, 50.0), region="sh", **kwargs, val=2.0),
+    ]
+
+
+def commit(target, dataarrays):
+    """Write and flush, as an entrypoint iteration does."""
+    for da in dataarrays:
+        target.write(da)
+    target.flush()
+
+
+class XarrayTargetContract:
+    """Behaviour shared by all formats, observed through as_dataset()."""
+
+    def test_as_dataset_without_commits(self, target):
+        xr.testing.assert_identical(target.as_dataset(), xr.Dataset())
+
+    def test_write_does_not_commit(self, target):
+        target.write(make_da())
+        xr.testing.assert_identical(target.as_dataset(), xr.Dataset())
+
+    def test_flush_without_writes(self, target):
+        target.flush()
+        xr.testing.assert_identical(target.as_dataset(), xr.Dataset())
+
+    def test_flush_rejects_variables_covering_different_blocks(self, target):
+        target.write(make_da("foo"))
+        target.write(make_da("foo", lons=(30.0, 40.0, 50.0)))
+        target.write(make_da("bar"))
+        with pytest.raises(ValueError):
+            target.flush()
+        xr.testing.assert_identical(target.as_dataset(), xr.Dataset())
+
+    def test_flush_rejects_sparse_cube(self, target):
+        a, b, c, d = make_da_blocks()
+        target.write(a)
+        target.write(b)
+        target.write(d)
+        with pytest.raises(ValueError):
+            target.flush()
+        xr.testing.assert_identical(target.as_dataset(), xr.Dataset())
+        target.write(c)  # complete the cube to allow flushing
+        target.flush()
+        expected = xr.combine_by_coords([a, b, c, d])
+        xr.testing.assert_identical(target.as_dataset(), expected)
+
+    def test_flush_rejects_duplicates(self, target):
+        target.write(make_da())
+        target.write(make_da())
+        with pytest.raises(ValueError):
+            target.flush()
+        xr.testing.assert_identical(target.as_dataset(), xr.Dataset())
+
+    def test_as_dataset_one_dataarray(self, target):
+        da = make_da()
+        commit(target, [da])
+        xr.testing.assert_identical(target.as_dataset(), da.to_dataset())
+
+    def test_as_dataset_two_blocks(self, target):
+        first, second, _, _ = make_da_blocks()
+        commit(target, [first, second])
+        xr.testing.assert_identical(
+            target.as_dataset(), xr.concat([first, second], dim="lon").to_dataset()
+        )
+
+    def test_as_dataset_two_variables(self, target):
+        foo, bar = make_da("foo"), make_da("bar")
+        commit(target, [foo, bar])
+        result = target.as_dataset()
+        assert list(result.data_vars) == ["foo", "bar"]
+        xr.testing.assert_identical(result, xr.merge([foo, bar]))
+
+    def test_as_dataset_two_variables_two_blocks(self, target):
+        a, b, _, _ = make_da_blocks()
+        c = a.rename("bar")
+        d = b.rename("bar")
+        commit(target, [a, c, b, d])  # interleaved, to cover out-of-order arrival
+        expected = xr.combine_by_coords([a, b, c, d])
+        xr.testing.assert_identical(target.as_dataset(), expected)
+
+    def test_as_dataset_two_variables_one_with_extra_dim(self, target):
+        foo = make_da(name="foo", region=None)
+        bar_nh = make_da(name="bar", region="nh")
+        bar_sh = make_da(name="bar", region="sh")
+        commit(target, [foo, bar_nh, bar_sh])
+        expected = xr.combine_by_coords([foo, bar_nh, bar_sh])
+        xr.testing.assert_identical(target.as_dataset(), expected)
+
+    def test_as_dataset_is_repeatable(self, target):
+        a, b, c, d = make_da_blocks()
+        commit(target, [a, b])
+        # Reading twice yields the same dataset
+        xr.testing.assert_identical(target.as_dataset(), target.as_dataset())
+        # Reading doesn't affect subsequent commits
+        commit(target, [c, d])
+        expected = xr.combine_by_coords([a, b, c, d])
+        xr.testing.assert_identical(target.as_dataset(), expected)
+
+    def test_later_commit_overrides_earlier(self, target):
+        commit(target, [make_da(region="nh", val=1.0), make_da(region="sh", val=1.0)])
+        commit(target, [make_da(region="nh", val=9.0)])
+        expected = xr.concat(
+            [make_da(region="nh", val=9.0), make_da(region="sh", val=1.0)], dim="region"
+        ).to_dataset()
+        xr.testing.assert_identical(target.as_dataset(), expected)
+
+    def test_commits_may_form_a_sparse_cube(self, target):
+        a, b, c, _ = make_da_blocks()
+        # Each commit is a cube on its own, the union of the two is not
+        commit(target, [b])
+        commit(target, [a, c])
+        expected = xr.combine_by_coords([a, b, c], join="outer", fill_value=np.nan)
+        xr.testing.assert_identical(target.as_dataset(), expected)
+
+    def test_commits_may_add_a_variable(self, target):
+        commit(target, [make_da("foo")])
+        commit(target, [make_da("bar")])
+        assert sorted(target.as_dataset().data_vars) == ["bar", "foo"]
+
+
+class TestXarrayTargetMemory(XarrayTargetContract):
+    @pytest.fixture
+    def target(self):
+        return XarrayTarget(format="memory")
+
+    def test_a_path_is_kept_but_not_written_to(self, tmpdir):
+        # The destination may be carried for a later write-out phase
+        target = XarrayTarget(format="memory", path=str(tmpdir / "test.nc"))
+        commit(target, [make_da()])
+        assert target.path == str(tmpdir / "test.nc")
+        assert os.listdir(str(tmpdir)) == []
+
+    def test_parallel_commits_reach_the_parent(self, target):
+        target.enable_parallel()
+        blocks = make_da_blocks()
+        parallel.parallel_processing(
+            commit,
+            [(target, [block]) for block in blocks],
+            2,
+        )
+        expected = xr.combine_by_coords(blocks)
+        xr.testing.assert_identical(expected, target.as_dataset())
+
+    def test_recovery_is_not_supported(self, target):
+        with pytest.raises(NotImplementedError):
+            target.enable_recovery()
+
+
+class TestXarrayTargetNetCDF(XarrayTargetContract):
+    @pytest.fixture
+    def target(self, tmpdir):
+        return XarrayTarget(path=str(tmpdir / "test.nc"), format="netcdf")
+
+    def test_path_is_required(self):
+        with pytest.raises(pydantic.ValidationError):
+            XarrayTarget(format="netcdf")
+
+    def test_nothing_is_written_without_a_commit(self, target):
+        target.flush()  # nothing staged
+        assert not os.path.exists(target.path)
+        target.write(make_da())  # staged, but not flushed
+        assert not os.path.exists(target.path)
+        target.write(make_da())  # duplicate will be rejected by flush
+        with pytest.raises(ValueError):
+            target.flush()
+        assert not os.path.exists(target.path)
+
+    def test_targets_do_not_share_writes(self, tmpdir):
+        first = XarrayTarget(path=str(tmpdir / "first.nc"), format="netcdf")
+        second = XarrayTarget(path=str(tmpdir / "second.nc"), format="netcdf")
+        commit(first, [make_da("foo")])
+        commit(second, [make_da("bar")])
+        xr.testing.assert_identical(
+            xr.load_dataset(first.path), make_da("foo").to_dataset()
+        )
+        xr.testing.assert_identical(
+            xr.load_dataset(second.path), make_da("bar").to_dataset()
+        )
+
+    def test_flush_single(self, target):
+        da = make_da()
+        commit(target, [da])
+        xr.testing.assert_identical(xr.load_dataset(target.path), da.to_dataset())
+        # Empty flush doesn't change anything
+        target.flush()
+        xr.testing.assert_identical(xr.load_dataset(target.path), da.to_dataset())
+
+    def test_flush_twice(self, target):
+        first, second = make_da(region="nh", val=1.0), make_da(region="sh", val=2.0)
+        commit(target, [first])
+        commit(target, [second])
+        expected = xr.concat([first, second], dim="region").to_dataset()
+        xr.testing.assert_identical(xr.load_dataset(target.path), expected)
+
+    def test_flush_keeps_the_previous_commit_on_failure(self, target):
+        commit(target, [make_da(region="nh", val=1.0)])
+        committed = xr.load_dataset(target.path)
+
+        with patch.object(xr.Dataset, "to_netcdf", side_effect=OSError("interrupted")):
+            target.write(make_da(region="sh", val=2.0))
+            with pytest.raises(OSError):
+                target.flush()
+
+        xr.testing.assert_identical(xr.load_dataset(target.path), committed)
+        # The object does not claim more than is on disk
+        xr.testing.assert_identical(target.as_dataset(), xr.load_dataset(target.path))
+
+    def test_flush_can_be_retried_after_a_failure(self, target):
+        da = make_da(region="nh", val=1.0)
+        with patch.object(xr.Dataset, "to_netcdf", side_effect=OSError("interrupted")):
+            target.write(da)
+            with pytest.raises(OSError):
+                target.flush()
+        target.flush()  # the queue survived, so the retry really commits
+        xr.testing.assert_identical(xr.load_dataset(target.path), da.to_dataset())
+
+    def test_clean_removes_debris_from_an_interrupted_commit(self, target, tmpdir):
+        commit(target, [make_da()])
+        before = set(os.listdir(str(tmpdir)))
+        # A commit killed between writing and moving into place leaves debris
+        with patch("os.replace", side_effect=OSError("killed")):
+            target.write(make_da(lons=(30.0, 40.0, 50.0)))
+            with pytest.raises(OSError):
+                target.flush()
+        assert set(os.listdir(str(tmpdir))) > before
+        target.clean()
+        assert os.listdir(str(tmpdir)) == ["test.nc"]
+
+    def test_parallel_commits_are_not_lost(self, target):
+        target.enable_parallel()
+        regions = ["nh", "sh", "eq", "pl"]
+        parallel.parallel_processing(
+            commit,
+            [
+                (target, [make_da(region=r, val=float(i))])
+                for i, r in enumerate(regions)
+            ],
+            2,
+        )
+        written = xr.load_dataset(target.path)["foo"]
+        np.testing.assert_array_equal(np.sort(written.region.values), sorted(regions))
+        for i, region in enumerate(regions):
+            np.testing.assert_array_equal(written.sel(region=region).values, float(i))
+
+    def test_recovery_without_existing_file(self, target):
+        target.enable_recovery()
+        xr.testing.assert_identical(target.as_dataset(), xr.Dataset())
+
+    def test_recovery_loads_existing_file(self, target):
+        da = make_da()
+        commit(target, [da])
+        assert os.path.isfile(target.path)
+        resumed = XarrayTarget(
+            path=target.path, format="netcdf"
+        )  # as a resumed run would create
+        resumed.enable_recovery()
+        xr.testing.assert_identical(resumed.as_dataset(), da.to_dataset())
+
+    def test_a_fresh_run_overwrites_an_existing_file(self, target):
+        # Recovery is opt-in, so without it the previous results are replaced
+        commit(target, [make_da(region="nh", val=1.0)])
+        assert os.path.isfile(target.path)
+        fresh = XarrayTarget(path=target.path, format="netcdf")
+        commit(fresh, [make_da(region="sh", val=2.0)])
+        xr.testing.assert_identical(
+            xr.load_dataset(fresh.path), make_da(region="sh", val=2.0).to_dataset()
+        )
+
+    def test_recovery_keeps_and_overrides_previous_results(self, target):
+        a, b, c, d = make_da_blocks()
+        a99 = a.copy(data=np.full_like(a.data, fill_value=99.0))
+        commit(target, [a, c])
+        resumed = XarrayTarget(path=target.path, format="netcdf")
+        resumed.enable_recovery()
+        # nh is recomputed, and a block that was never reached is added
+        commit(resumed, [a99])  # "recomputed"
+        commit(resumed, [b, d])  # new block
+        expected = xr.combine_by_coords([a99, b, c, d])
+        xr.testing.assert_identical(resumed.as_dataset(), expected)
+        xr.testing.assert_identical(xr.load_dataset(resumed.path), expected)
+
+    def test_recovery_after_an_interrupted_commit(self, target):
+        # The interrupted commit left the previous one readable, so a resumed run
+        # picks it up instead of failing on a half-written file
+        a, b, _, _ = make_da_blocks()
+        commit(target, [a])
+        with patch.object(xr.Dataset, "to_netcdf", side_effect=OSError("interrupted")):
+            target.write(b)
+            with pytest.raises(OSError):
+                target.flush()
+
+        resumed = XarrayTarget(path=target.path)
+        resumed.enable_recovery()
+        xr.testing.assert_identical(resumed.as_dataset(), a.to_dataset())


### PR DESCRIPTION
⚠️ The description is currently out-of-date, see my last comment.

### Description

Adds an `"xarray"` target type with transactional behaviour for collecting xarray Dataset/DataArray parts and merging them into a single output Dataset.

Keeps a local staging area for collecting objects, which can be flushed to a shared collection once a complete/dense datacube has been staged. I don't expect that only being able to flush full cubes is a significant limitation in practice. It simplifies merging and makes recovery safer.

I intend to use this for several reduction-type products where the results aren't fields, in particular Hovmöller diagrams and indices for MJO, SSW and weather regimes. CoverageJSON will be added as an output format later.

### API overview

- `XarrayTarget.write(ds)`: add a DataArray/Dataset to the local staging area.
- `XarrayTarget.flush()`: merge all objects in the staging area, commit to the shared collection, and write the current collection to disk if the formal allows (see below)
- `XarrayTarget.clean()`: clean up any locks and temporary files.
- `XarrayTarget.as_dataset()`: 
- `XarrayTarget.enable_recovery()`: recover previous data from disk.
- `XarrayTarget.enable_parallel()`: replace the shared collection with one from the multiprocessing manager.

### Output format "netcdf"

```yaml
target:
  type: xarray
  path: 'output.nc'
  format: 'netcdf'
```

Objects are collected in memory and written to disk when flushing. The entire NetCDF file is replaced on every write. Recovery from a written file is possible, so checkpointing can be used by entrypoints.

### Ouput format: "memory"

```yaml
target:
  type: xarray
  format: 'memory'
```

Objects are only collected in memory for the entrypoint to decide what to do with at the end (access with `.as_dataset()`). Since no intermediate results are persisted on disk, recovery cannot be enabled. Could be useful when further post-processing of the generated dataset is required, e.g., statistics to be calculated. I'm open to splitting this off into a separate class if the current toggle via `format` is considered too confusing/awkward. 

### Tests

The test suite covers basics of the stage/commit transactional behaviour and the NetCDF writing/recovery.


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
